### PR TITLE
Move Dockerfile to root dir.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+WORKDIR /go/src/github.com/metalkube/baremetal-operator
+COPY . .
+RUN go build -o build/_output/bin/baremetal-operator cmd/manager/main.go
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/metalkube/baremetal-operator/build/_output/bin/baremetal-operator /
+RUN if ! rpm -q genisoimage; then yum install -y genisoimage && yum clean all && rm -rf /var/cache/yum/*; fi


### PR DESCRIPTION
Move a copy of build/Dockerfile into the root of the repo.  That's
where Dockerfiles reside in most other OpenShift repos.  We also plan
to change this file upstream to not be based on an OpenShift base, so
this copy will remain the one we use in OpenShift.