### PR TITLE
Dockerfile: Sync build change from upstream Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/metal3-io/baremetal-operator
 COPY . .
-RUN go build -o build/_output/bin/baremetal-operator cmd/manager/main.go
+RUN make build
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/build/_output/bin/baremetal-operator /


### PR DESCRIPTION
Commit 9384e31977aba0e183d2a5d2646770632e349d20 changed the upstream
Dockerfile (build/Dockerfile) to use "make build".  Do the same for
the OpenShift Dockerfile.