### PR TITLE
use make to build binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/metal3-io/baremetal-operator
 COPY . .
-RUN go build -o build/_output/bin/baremetal-operator cmd/manager/main.go
+RUN make build
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/build/_output/bin/baremetal-operator /


### PR DESCRIPTION
Use make to build the binary for the operator so it is built
consistently with the upstream instructions.