### PR TITLE
Configure metrics endpoint.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,6 +31,7 @@ func printVersion() {
 
 func main() {
 	devLogging := flag.Bool("dev", false, "enable dev logging")
+	metricsAddr := flag.String("metrics-addr", "127.0.0.1:8080", "The address the metric endpoint binds to.")
 	flag.Parse()
 
 	// The logger instantiated here can be changed to any logger
@@ -61,8 +62,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	opts := manager.Options{
+		Namespace:          namespace,
+		MetricsBindAddress: *metricsAddr,
+	}
+
 	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
+	mgr, err := manager.New(cfg, opts)
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)


### PR DESCRIPTION
This patch configures a prometheus metrics endpoint for the
baremetal-operator.  The metrics endpoint only listens on localhost by
default, but this can be configured through a command line argument.

This can be tested with `make run` and then run the following command:
  $ curl http://localhost:8080/metrics

Closes #245