### PR TITLE
Run gosec with lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ lint:
 	go vet ./pkg/... ./cmd/...
 	cp $(crd_file) $(crd_tmp); make crd; if ! diff -q $(crd_file) $(crd_tmp); then mv $(crd_tmp) $(crd_file); exit 1; else rm $(crd_tmp); fi
 
+.PHONY: test-sec
+test-sec:
+	@which gosec 2> /dev/null >&1 || { echo "gosec must be installed to lint code";  exit 1; }
+	gosec -severity medium --confidence medium -quiet ./...
+
 .PHONY: docs
 docs: $(patsubst %.dot,%.png,$(wildcard docs/*.dot))
 

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,11 @@ lint: test-sec
 	cp $(crd_file) $(crd_tmp); make crd; if ! diff -q $(crd_file) $(crd_tmp); then mv $(crd_tmp) $(crd_file); exit 1; else rm $(crd_tmp); fi
 
 .PHONY: test-sec
-test-sec:
-	@which gosec 2> /dev/null >&1 || { echo "gosec must be installed to lint code";  exit 1; }
+test-sec: $GOPATH/bin/gosec
 	gosec -severity medium --confidence medium -quiet ./...
+
+$GOPATH/bin/gosec:
+	go get -u github.com/securego/gosec/cmd/gosec
 
 .PHONY: docs
 docs: $(patsubst %.dot,%.png,$(wildcard docs/*.dot))

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ crd_file=deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
 crd_tmp=.crd.yaml.tmp
 
 .PHONY: lint
-lint:
+lint: test-sec
 	golint -set_exit_status pkg/... cmd/...
 	go vet ./pkg/... ./cmd/...
 	cp $(crd_file) $(crd_tmp); make crd; if ! diff -q $(crd_file) $(crd_tmp); then mv $(crd_tmp) $(crd_file); exit 1; else rm $(crd_tmp); fi

--- a/cmd/make-virt-host/main.go
+++ b/cmd/make-virt-host/main.go
@@ -146,6 +146,7 @@ func main() {
 	}
 
 	// Figure out the MAC for the VM
+	// #nosec
 	virshOut, err := exec.Command("sudo", "virsh", "dumpxml", virshDomain).Output()
 	if err != nil {
 		fmt.Fprintf(os.Stderr,

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -610,6 +610,8 @@ func (p *ironicProvisioner) getImageChecksum() (string, error) {
 	}
 	if isURL {
 		p.log.Info("looking for checksum for image", "URL", checksum)
+		// #nosec
+		// TODO: Are there more ways to constraint the URL that's given here?
 		resp, err := http.Get(checksum)
 		if err != nil {
 			return "", errors.Wrap(err, "Could not fetch image checksum")


### PR DESCRIPTION
This enables gosec to run as part of the lint target, therefore running
it as well as part of CI.

This also adds the needed command to install it as part of the CI run.