### PR TITLE
Update to latest gophercloud revision

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -263,7 +263,7 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:b9b8297d55b96144075d3a18b3a8658acd95ff6c8c4a00159221c0a0e4fbcca1"
+  digest = "1:f60e7e9be98ff9d00371b24fcbe92e019b809b592d7d10b4cb61965ba59610f6"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -280,7 +280,7 @@
     "pagination",
   ]
   pruneopts = "NT"
-  revision = "157432124aab520975efedb5e54b95287785578d"
+  revision = "2d40ff7a3874e2b376ff245d549e7757048cd65c"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,7 +49,7 @@ required = [
 
 [[constraint]]
   name = "github.com/gophercloud/gophercloud"
-  revision = "157432124aab520975efedb5e54b95287785578d"
+  revision = "2d40ff7a3874e2b376ff245d549e7757048cd65c"
 
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"

--- a/vendor/github.com/gophercloud/gophercloud/acceptance/openstack/compute/v2/compute.go
+++ b/vendor/github.com/gophercloud/gophercloud/acceptance/openstack/compute/v2/compute.go
@@ -614,6 +614,34 @@ func CreateServerGroup(t *testing.T, client *gophercloud.ServiceClient, policy s
 	return sg, nil
 }
 
+// CreateServerGroupMicroversion will create a server with a random name using 2.64 microversion. An error will be
+// returned if the server group failed to be created.
+func CreateServerGroupMicroversion(t *testing.T, client *gophercloud.ServiceClient) (*servergroups.ServerGroup, error) {
+	name := tools.RandomString("ACPTTEST", 16)
+	policy := "anti-affinity"
+	maxServerPerHost := 3
+
+	t.Logf("Attempting to create %s server group with max server per host = %d: %s", policy, maxServerPerHost, name)
+
+	sg, err := servergroups.Create(client, &servergroups.CreateOpts{
+		Name:   name,
+		Policy: policy,
+		Rules: &servergroups.Rules{
+			MaxServerPerHost: maxServerPerHost,
+		},
+	}).Extract()
+
+	if err != nil {
+		return nil, err
+	}
+
+	t.Logf("Successfully created server group %s", name)
+
+	th.AssertEquals(t, sg.Name, name)
+
+	return sg, nil
+}
+
 // CreateServerInServerGroup works like CreateServer but places the instance in
 // a specified Server Group.
 func CreateServerInServerGroup(t *testing.T, client *gophercloud.ServiceClient, serverGroup *servergroups.ServerGroup) (*servers.Server, error) {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/doc.go
@@ -1,0 +1,13 @@
+/*
+Package apiversions provides information about the versions supported by a specific Ironic API.
+
+	Example to list versions
+
+		allVersions, err := apiversions.List(client.ServiceClient()).AllPages()
+
+	Example to get a specific version
+
+		actual, err := apiversions.Get(client.ServiceClient(), "v1").Extract()
+
+*/
+package apiversions

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/requests.go
@@ -1,0 +1,17 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// List lists all the API versions available to end users.
+func List(client *gophercloud.ServiceClient) (r ListResult) {
+	_, r.Err = client.Get(listURL(client), &r.Body, nil)
+	return
+}
+
+// Get will get a specific API version, specified by major ID.
+func Get(client *gophercloud.ServiceClient, v string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, v), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/results.go
@@ -1,0 +1,62 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// APIVersions represents the result from getting a list of all versions available
+type APIVersions struct {
+	DefaultVersion APIVersion   `json:"default_version"`
+	Versions       []APIVersion `json:"versions"`
+}
+
+// APIVersion represents an API version for Ironic
+type APIVersion struct {
+	// ID is the unique identifier of the API version.
+	ID string `json:"id"`
+
+	// MinVersion is the minimum microversion supported.
+	MinVersion string `json:"min_version"`
+
+	// Status is the API versions status.
+	Status string `json:"status"`
+
+	// Version is the maximum microversion supported.
+	Version string `json:"version"`
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// ListResult represents the result of a list operation.
+type ListResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a get result and extracts an API version resource.
+func (r GetResult) Extract() (*APIVersion, error) {
+	var s struct {
+		Version APIVersion `json:"version"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &s.Version, nil
+}
+
+// Extract is a function that accepts a list result and extracts an APIVersions resource
+func (r ListResult) Extract() (*APIVersions, error) {
+	var version APIVersions
+
+	err := r.ExtractInto(&version)
+	if err != nil {
+		return nil, err
+	}
+
+	return &version, nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/testing/fixtures.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/testing/fixtures.go
@@ -1,0 +1,106 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/apiversions"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+const IronicAPIAllVersionResponse = `
+{
+  "default_version": {
+    "status": "CURRENT",
+    "min_version": "1.1",
+    "version": "1.56",
+    "id": "v1",
+    "links": [
+      {
+        "href": "http://localhost:6385/v1/",
+        "rel": "self"
+      }
+    ]
+  },
+  "versions": [
+    {
+      "status": "CURRENT",
+      "min_version": "1.1",
+      "version": "1.56",
+      "id": "v1",
+      "links": [
+        {
+          "href": "http://localhost:6385/v1/",
+          "rel": "self"
+        }
+      ]
+    }
+  ],
+  "name": "OpenStack Ironic API",
+  "description": "Ironic is an OpenStack project which aims to provision baremetal machines."
+}
+`
+
+const IronicAPIVersionResponse = `
+{
+  "media_types": [
+    {
+      "base": "application/json",
+      "type": "application/vnd.openstack.ironic.v1+json"
+    }
+  ],
+  "version": {
+    "status": "CURRENT",
+    "min_version": "1.1",
+    "version": "1.56",
+    "id": "v1",
+    "links": [
+      {
+        "href": "http://localhost:6385/v1/",
+        "rel": "self"
+      }
+    ]
+  },
+  "id": "v1"
+}
+`
+
+var IronicAPIVersion1Result = apiversions.APIVersion{
+	ID:         "v1",
+	Status:     "CURRENT",
+	MinVersion: "1.1",
+	Version:    "1.56",
+}
+
+var IronicAllAPIVersionResults = apiversions.APIVersions{
+	DefaultVersion: IronicAPIVersion1Result,
+	Versions: []apiversions.APIVersion{
+		IronicAPIVersion1Result,
+	},
+}
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, IronicAPIAllVersionResponse)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/v1/", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, IronicAPIVersionResponse)
+	})
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/apiversions/urls.go
@@ -1,0 +1,13 @@
+package apiversions
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+func getURL(c *gophercloud.ServiceClient, version string) string {
+	return c.ServiceURL(version)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL()
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/requests.go
@@ -388,9 +388,9 @@ func GetSupportedBootDevices(client *gophercloud.ServiceClient, id string) (r Su
 // the value for ‘args’ is a keyword variable argument dictionary that is passed to the cleaning step
 // method.
 type CleanStep struct {
-	Interface string            `json:"interface" required:"true"`
-	Step      string            `json:"step" required:"true"`
-	Args      map[string]string `json:"args,omitempty"`
+	Interface string                 `json:"interface" required:"true"`
+	Step      string                 `json:"step" required:"true"`
+	Args      map[string]interface{} `json:"args,omitempty"`
 }
 
 // ProvisionStateOptsBuilder allows extensions to add additional parameters to the

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/doc.go
@@ -29,6 +29,34 @@ Example to Create a Server Group
 		panic(err)
 	}
 
+Example to Create a Server Group with additional microversion 2.64 fields
+
+	createOpts := servergroups.CreateOpts{
+		Name:   "my_sg",
+		Policy: "anti-affinity",
+        	Rules: &servergroups.Rules{
+            		MaxServerPerHost: 3,
+        	},
+	}
+
+	computeClient.Microversion = "2.64"
+	result := servergroups.Create(computeClient, createOpts)
+
+	serverGroup, err := result.Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	policy, err := servergroups.ExtractPolicy(result.Result)
+	if err != nil {
+		panic(err)
+	}
+
+	rules, err := servergroups.ExtractRules(result.Result)
+	if err != nil {
+		panic(err)
+	}
+
 Example to Delete a Server Group
 
 	sgID := "7a6f29ad-e34d-4368-951a-58a08f11cfb7"
@@ -36,5 +64,23 @@ Example to Delete a Server Group
 	if err != nil {
 		panic(err)
 	}
+
+Example to get additional fields with microversion 2.64 or later
+
+	computeClient.Microversion = "2.64"
+	result := servergroups.Get(computeClient, "616fb98f-46ca-475e-917e-2563e5a8cd19")
+
+	policy, err := servergroups.ExtractPolicy(result.Result)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Policy: %s\n", policy)
+
+	rules, err := servergroups.ExtractRules(result.Result)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Max server per host: %s\n", rules.MaxServerPerHost)
+
 */
 package servergroups

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/microversions.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/microversions.go
@@ -1,0 +1,32 @@
+package servergroups
+
+import "github.com/gophercloud/gophercloud"
+
+// ExtractPolicy will extract the policy attribute.
+// This requires the client to be set to microversion 2.64 or later.
+func ExtractPolicy(r gophercloud.Result) (string, error) {
+	var s struct {
+		Policy string `json:"policy"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server_group")
+
+	return s.Policy, err
+}
+
+// ExtractRules will extract the rules attribute.
+// This requires the client to be set to microversion 2.64 or later.
+func ExtractRules(r gophercloud.Result) (Rules, error) {
+	var s struct {
+		Rules Rules `json:"rules"`
+	}
+	err := r.ExtractIntoStructPtr(&s, "server_group")
+
+	return s.Rules, err
+}
+
+// Rules represents set of rules for a policy.
+type Rules struct {
+	// MaxServerPerHost specifies how many servers can reside on a single compute host.
+	// It can be used only with the "anti-affinity" policy.
+	MaxServerPerHost int `json:"max_server_per_host,omitempty"`
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/requests.go
@@ -21,11 +21,19 @@ type CreateOptsBuilder interface {
 
 // CreateOpts specifies Server Group creation parameters.
 type CreateOpts struct {
-	// Name is the name of the server group
+	// Name is the name of the server group.
 	Name string `json:"name" required:"true"`
 
-	// Policies are the server group policies
-	Policies []string `json:"policies" required:"true"`
+	// Policies are the server group policies.
+	Policies []string `json:"policies,omitempty"`
+
+	// Policy specifies the name of a policy.
+	// Requires microversion 2.64 or later.
+	Policy string `json:"policy,omitempty"`
+
+	// Rules specifies the set of rules.
+	// Requires microversion 2.64 or later.
+	Rules *Rules `json:"rules,omitempty"`
 }
 
 // ToServerGroupCreateMap constructs a request body from CreateOpts.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/results.go
@@ -6,6 +6,8 @@ import (
 )
 
 // A ServerGroup creates a policy for instance placement in the cloud.
+// You should use extract methods from microversions.go to retrieve additional
+// fields.
 type ServerGroup struct {
 	// ID is the unique ID of the Server Group.
 	ID string `json:"id"`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups/testing/fixtures.go
@@ -51,6 +51,25 @@ const GetOutput = `
 }
 `
 
+// GetOutputMicroversion is a sample response to a Get call with microversion set to 2.64
+const GetOutputMicroversion = `
+{
+    "server_group": {
+        "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
+        "name": "test",
+        "policies": [
+            "anti-affinity"
+        ],
+        "policy": "anti-affinity",
+        "rules": {
+          "max_server_per_host": 3
+        },
+        "members": [],
+        "metadata": {}
+    }
+}
+`
+
 // CreateOutput is a sample response to a Post call
 const CreateOutput = `
 {
@@ -60,6 +79,25 @@ const CreateOutput = `
         "policies": [
             "anti-affinity"
         ],
+        "members": [],
+        "metadata": {}
+    }
+}
+`
+
+// CreateOutputMicroversion is a sample response to a Post call with microversion set to 2.64
+const CreateOutputMicroversion = `
+{
+    "server_group": {
+        "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
+        "name": "test",
+        "policies": [
+            "anti-affinity"
+        ],
+        "policy": "anti-affinity",
+        "rules": {
+          "max_server_per_host": 3
+        },
         "members": [],
         "metadata": {}
     }
@@ -126,6 +164,18 @@ func HandleGetSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleGetMicroversionSuccessfully configures the test server to respond to a Get request
+// for an existing server group with microversion set to 2.64
+func HandleGetMicroversionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-server-groups/4d8c3732-a248-40ed-bebc-539a6ffd25c0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, GetOutputMicroversion)
+	})
+}
+
 // HandleCreateSuccessfully configures the test server to respond to a Create request
 // for a new server group
 func HandleCreateSuccessfully(t *testing.T) {
@@ -145,6 +195,32 @@ func HandleCreateSuccessfully(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		fmt.Fprintf(w, CreateOutput)
+	})
+}
+
+// HandleCreateMicroversionSuccessfully configures the test server to respond to a Create request
+// for a new server group with microversion set to 2.64
+func HandleCreateMicroversionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-server-groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+{
+    "server_group": {
+        "name": "test",
+        "policies": [
+            "anti-affinity"
+        ],
+        "policy": "anti-affinity",
+        "rules": {
+            "max_server_per_host": 3
+        }
+    }
+}
+`)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, CreateOutputMicroversion)
 	})
 }
 


### PR DESCRIPTION
This change pulls includes:
 - Improvement: return versions supported by the API
 - Bug fix: Reformat Args in CleanStep from `map[string]string` to `map[string]interface{}`

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>