### PR TITLE
only skip inspection for fully provisioned hosts

### DIFF
--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -517,9 +517,14 @@ func (host *BareMetalHost) CredentialsNeedValidation(currentSecret corev1.Secret
 // NeedsHardwareInspection looks at the state of the host to determine
 // if hardware inspection should be run.
 func (host *BareMetalHost) NeedsHardwareInspection() bool {
-	if host.WasExternallyProvisioned() || host.Spec.ConsumerRef != nil {
+	if host.WasExternallyProvisioned() {
 		// Never perform inspection if we already know something is
-		// using the host.
+		// using the host and we didn't provision it.
+		return false
+	}
+	if host.WasProvisioned() {
+		// Never perform inspection if we have already provisioned
+		// this host, because we don't want to reboot it.
 		return false
 	}
 	return host.Status.HardwareDetails == nil

--- a/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
+++ b/pkg/apis/metal3/v1alpha1/baremetalhost_types_test.go
@@ -106,7 +106,7 @@ func TestHostNeedsHardwareInspection(t *testing.T) {
 		},
 
 		{
-			Scenario: "host with consumer",
+			Scenario: "unprovisioned host with consumer",
 			Host: BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
@@ -114,6 +114,24 @@ func TestHostNeedsHardwareInspection(t *testing.T) {
 				},
 				Spec: BareMetalHostSpec{
 					ConsumerRef: &corev1.ObjectReference{},
+				},
+			},
+			Expected: true,
+		},
+
+		{
+			Scenario: "provisioned host",
+			Host: BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost",
+					Namespace: "myns",
+				},
+				Status: BareMetalHostStatus{
+					Provisioning: ProvisionStatus{
+						Image: Image{
+							URL: "not-empty",
+						},
+					},
 				},
 			},
 			Expected: false,

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -541,7 +541,7 @@ func (p *ironicProvisioner) InspectHardware() (result provisioner.Result, detail
 		return
 	}
 
-	// Introspection is ongoing
+	// Introspection is done
 	p.log.Info("getting hardware details from inspection")
 	introData := introspection.GetIntrospectionData(p.inspector, ironicNode.UUID)
 	data, err := introData.Extract()


### PR DESCRIPTION
Using the presence of a consumerRef value to indicate that a host is
in use means we have a race condition when a host is first registered
if the machine controller grabs the host and allocates it to a
machine before the host has finished inspection. To avoid the race,
use the WasProvisioned() function to test whether a host has actually
been provisioned instead of looking only at the consumer reference.

This update requires changing the expected behavior in an existing
unit test (because it was wrong) and adding a new unit test for the
new case.