### PR TITLE
move ironic settings logging to startup function

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -71,6 +71,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		provisionerFactory = demo.New
 	default:
 		provisionerFactory = ironic.New
+		ironic.LogStartup()
 	}
 	return &ReconcileBareMetalHost{
 		client:             mgr.GetClient(),

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -93,15 +93,20 @@ type ironicProvisioner struct {
 	publisher provisioner.EventPublisher
 }
 
-// A private function to construct an ironicProvisioner (rather than a
-// Provisioner interface) in a consistent way for tests.
-func newProvisioner(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (*ironicProvisioner, error) {
+// LogStartup produces useful logging information that we only want to
+// emit once on startup but that is interal to this package.
+func LogStartup() {
 	log.Info("ironic settings",
 		"endpoint", ironicEndpoint,
 		"inspectorEndpoint", inspectorEndpoint,
 		"deployKernelURL", deployKernelURL,
 		"deployRamdiskURL", deployRamdiskURL,
 	)
+}
+
+// A private function to construct an ironicProvisioner (rather than a
+// Provisioner interface) in a consistent way for tests.
+func newProvisioner(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (*ironicProvisioner, error) {
 	client, err := noauth.NewBareMetalNoAuth(noauth.EndpointOpts{
 		IronicEndpoint: ironicEndpoint,
 	})


### PR DESCRIPTION
Instead of logging all of the ironic settings every time the
reconciler builds a provisioner, log them once on startup.

We don't use the init() function for this because logging isn't
configured yet by the time that is called.

From https://github.com/metal3-io/baremetal-operator/pull/274