### PR TITLE
make access details more dynamic

### DIFF
--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -4,6 +4,21 @@ import (
 	"strings"
 )
 
+func init() {
+	registerFactory("idrac", newIDRACAccessDetails)
+	registerFactory("idrac+http", newIDRACAccessDetails)
+	registerFactory("idrac+https", newIDRACAccessDetails)
+}
+
+func newIDRACAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+	return &iDracAccessDetails{
+		bmcType:  bmcType,
+		portNum:  portNum,
+		hostname: hostname,
+		path:     path,
+	}, nil
+}
+
 type iDracAccessDetails struct {
 	bmcType  string
 	portNum  string

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -1,5 +1,18 @@
 package bmc
 
+func init() {
+	registerFactory("ipmi", newIPMIAccessDetails)
+	registerFactory("libvirt", newIPMIAccessDetails)
+}
+
+func newIPMIAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+	return &ipmiAccessDetails{
+		bmcType:  bmcType,
+		portNum:  portNum,
+		hostname: hostname,
+	}, nil
+}
+
 type ipmiAccessDetails struct {
 	bmcType  string
 	portNum  string

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -1,5 +1,17 @@
 package bmc
 
+func init() {
+	registerFactory("irmc", newIRMCAccessDetails)
+}
+
+func newIRMCAccessDetails(bmcType, portNum, hostname, path string) (AccessDetails, error) {
+	return &iRMCAccessDetails{
+		bmcType:  bmcType,
+		portNum:  portNum,
+		hostname: hostname,
+	}, nil
+}
+
 type iRMCAccessDetails struct {
 	bmcType  string
 	portNum  string
@@ -35,7 +47,7 @@ func (a *iRMCAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	if a.portNum != "" {
 		result["irmc_port"] = a.portNum
 	}
-	
+
 	return result
 }
 


### PR DESCRIPTION
Instead of hard-coding the creation of the AccessDetails structs in one function, register the factories for making different types and associate them with the values that show up in the URL scheme field to select them.

Merging https://github.com/openshift/baremetal-operator/pull/39