### PR TITLE
Install golint in Makefile if needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ go:
   - "1.11.5"
 
 before_install:
-  - go get golang.org/x/lint/golint
-  - go get -u github.com/securego/gosec/cmd/gosec
   - go get github.com/golang/dep/cmd/dep
   - git clone --branch=v0.8.x --depth=1 https://github.com/operator-framework/operator-sdk $GOPATH/src/github.com/operator-framework/operator-sdk && pushd $GOPATH/src/github.com/operator-framework/operator-sdk && make dep && make install && popd
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ crd_file=deploy/crds/metal3_v1alpha1_baremetalhost_crd.yaml
 crd_tmp=.crd.yaml.tmp
 
 .PHONY: lint
-lint: test-sec
+lint: test-sec $GOPATH/bin/golint
 	golint -set_exit_status pkg/... cmd/...
 	go vet ./pkg/... ./cmd/...
 	cp $(crd_file) $(crd_tmp); make generate; if ! diff -q $(crd_file) $(crd_tmp); then mv $(crd_tmp) $(crd_file); exit 1; else rm $(crd_tmp); fi
@@ -77,6 +77,9 @@ test-sec: $GOPATH/bin/gosec
 
 $GOPATH/bin/gosec:
 	go get -u github.com/securego/gosec/cmd/gosec
+
+$GOPATH/bin/golint:
+	go get -u golang.org/x/lint/golint
 
 .PHONY: docs
 docs: $(patsubst %.dot,%.png,$(wildcard docs/*.dot))


### PR DESCRIPTION
This syncs the makefile with upstream so golint is installed as well as
gosec automatically if needed.

Related to https://github.com/metal3-io/baremetal-operator/pull/311
