### PR TITLE
Bug 1781833: Cherry-pick virtual media changes to 4.3

### DIFF
--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -46,6 +46,11 @@ type AccessDetails interface {
 
 	// Boot interface to set
 	BootInterface() string
+
+	ManagementInterface() string
+	PowerInterface() string
+	RAIDInterface() string
+	VendorInterface() string
 }
 
 func getParsedURL(address string) (parsedURL *url.URL, err error) {

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -333,7 +333,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:    "redfish://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
-			boot:     "pxe",
+			boot:     "ipxe",
 		},
 
 		{

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -338,7 +338,7 @@ func TestStaticDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "redfish virtual media",
-			input:    "redfish+virtualmedia://192.168.122.1",
+			input:    "redfish-virtualmedia://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
 			boot:     "redfish-virtual-media",
@@ -346,7 +346,7 @@ func TestStaticDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "ilo5 virtual media",
-			input:    "ilo5+virtualmedia://192.168.122.1",
+			input:    "ilo5-virtualmedia://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
 			boot:     "redfish-virtual-media",
@@ -565,7 +565,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "Redfish virtual media",
-			input:    "redfish+virtualmedia://192.168.122.1/foo/bar",
+			input:    "redfish-virtualmedia://192.168.122.1/foo/bar",
 			expects: map[string]string{
 				"redfish_address":   "https://192.168.122.1",
 				"redfish_system_id": "/foo/bar",
@@ -576,7 +576,7 @@ func TestDriverInfo(t *testing.T) {
 
 		{
 			Scenario: "ilo5 virtual media",
-			input:    "ilo5+virtualmedia://192.168.122.1/foo/bar",
+			input:    "ilo5-virtualmedia://192.168.122.1/foo/bar",
 			expects: map[string]string{
 				"redfish_address":   "https://192.168.122.1",
 				"redfish_system_id": "/foo/bar",

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -351,6 +351,14 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:   "redfish",
 			boot:     "redfish-virtual-media",
 		},
+
+		{
+			Scenario: "idrac virtual media",
+			input:    "idrac-virtualmedia://192.168.122.1",
+			needsMac: true,
+			driver:   "idrac",
+			boot:     "idrac-redfish-virtual-media",
+		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			acc, err := NewAccessDetails(tc.input)
@@ -577,6 +585,17 @@ func TestDriverInfo(t *testing.T) {
 		{
 			Scenario: "ilo5 virtual media",
 			input:    "ilo5-virtualmedia://192.168.122.1/foo/bar",
+			expects: map[string]string{
+				"redfish_address":   "https://192.168.122.1",
+				"redfish_system_id": "/foo/bar",
+				"redfish_password":  "",
+				"redfish_username":  "",
+			},
+		},
+
+		{
+			Scenario: "idrac virtual media",
+			input:    "idrac-virtualmedia://192.168.122.1/foo/bar",
 			expects: map[string]string{
 				"redfish_address":   "https://192.168.122.1",
 				"redfish_system_id": "/foo/bar",

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -335,6 +335,14 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:   "redfish",
 			boot:     "pxe",
 		},
+
+		{
+			Scenario: "redfish virtual media",
+			input:    "redfish+virtualmedia://192.168.122.1",
+			needsMac: true,
+			driver:   "redfish",
+			boot:     "redfish-virtual-media",
+		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			acc, err := NewAccessDetails(tc.input)
@@ -542,6 +550,17 @@ func TestDriverInfo(t *testing.T) {
 			expects: map[string]string{
 				"redfish_address":   "https://[fe80::fc33:62ff:fe83:8a76]:8080",
 				"redfish_system_id": "/foo",
+				"redfish_password":  "",
+				"redfish_username":  "",
+			},
+		},
+
+		{
+			Scenario: "Redfish virtual media",
+			input:    "redfish+virtualmedia://192.168.122.1/foo/bar",
+			expects: map[string]string{
+				"redfish_address":   "https://192.168.122.1",
+				"redfish_system_id": "/foo/bar",
 				"redfish_password":  "",
 				"redfish_username":  "",
 			},

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -343,6 +343,14 @@ func TestStaticDriverInfo(t *testing.T) {
 			driver:   "redfish",
 			boot:     "redfish-virtual-media",
 		},
+
+		{
+			Scenario: "ilo5 virtual media",
+			input:    "ilo5+virtualmedia://192.168.122.1",
+			needsMac: true,
+			driver:   "redfish",
+			boot:     "redfish-virtual-media",
+		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			acc, err := NewAccessDetails(tc.input)
@@ -558,6 +566,17 @@ func TestDriverInfo(t *testing.T) {
 		{
 			Scenario: "Redfish virtual media",
 			input:    "redfish+virtualmedia://192.168.122.1/foo/bar",
+			expects: map[string]string{
+				"redfish_address":   "https://192.168.122.1",
+				"redfish_system_id": "/foo/bar",
+				"redfish_password":  "",
+				"redfish_username":  "",
+			},
+		},
+
+		{
+			Scenario: "ilo5 virtual media",
+			input:    "ilo5+virtualmedia://192.168.122.1/foo/bar",
 			expects: map[string]string{
 				"redfish_address":   "https://192.168.122.1",
 				"redfish_system_id": "/foo/bar",

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -70,3 +70,19 @@ func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfa
 func (a *iDracAccessDetails) BootInterface() string {
 	return "ipxe"
 }
+
+func (a *iDracAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *iDracAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *iDracAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *iDracAccessDetails) VendorInterface() string {
+	return ""
+}

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -66,3 +66,19 @@ func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 func (a *ipmiAccessDetails) BootInterface() string {
 	return "ipxe"
 }
+
+func (a *ipmiAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *ipmiAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *ipmiAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *ipmiAccessDetails) VendorInterface() string {
+	return ""
+}

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -58,3 +58,19 @@ func (a *iRMCAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 func (a *iRMCAccessDetails) BootInterface() string {
 	return "pxe"
 }
+
+func (a *iRMCAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *iRMCAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *iRMCAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *iRMCAccessDetails) VendorInterface() string {
+	return ""
+}

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -11,42 +11,45 @@ func init() {
 	registerFactory("redfish+https", newRedfishAccessDetails)
 	registerFactory("redfish-virtualmedia", newRedfishVirtualMediaAccessDetails)
 	registerFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails)
-	registerFactory("idrac-virtualmedia", newiDracRedfishVirtualMediaAccessDetails)
+	registerFactory("idrac-virtualmedia", newRedfishiDracVirtualMediaAccessDetails)
 }
 
-func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
+func redfishDetails(parsedURL *url.URL) *redfishAccessDetails {
 	return &redfishAccessDetails{
 		bmcType: parsedURL.Scheme,
 		host:    parsedURL.Host,
 		path:    parsedURL.Path,
-	}, nil
+	}
+}
+
+func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
+	return redfishDetails(parsedURL), nil
 }
 
 func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
-	return &redfishAccessDetails{
-		bmcType:        parsedURL.Scheme,
-		host:           parsedURL.Host,
-		path:           parsedURL.Path,
-		isVirtualMedia: true,
+	return &redfishVirtualMediaAccessDetails{
+		*redfishDetails(parsedURL),
 	}, nil
 }
 
-func newiDracRedfishVirtualMediaAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
-	return &redfishAccessDetails{
-		bmcType:        parsedURL.Scheme,
-		host:           parsedURL.Host,
-		path:           parsedURL.Path,
-		isVirtualMedia: true,
-		isiDrac:        true,
+func newRedfishiDracVirtualMediaAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
+	return &redfishiDracVirtualMediaAccessDetails{
+		*redfishDetails(parsedURL),
 	}, nil
 }
 
 type redfishAccessDetails struct {
-	bmcType        string
-	host           string
-	path           string
-	isVirtualMedia bool
-	isiDrac        bool
+	bmcType string
+	host    string
+	path    string
+}
+
+type redfishVirtualMediaAccessDetails struct {
+	redfishAccessDetails
+}
+
+type redfishiDracVirtualMediaAccessDetails struct {
+	redfishAccessDetails
 }
 
 const redfishDefaultScheme = "https"
@@ -64,9 +67,6 @@ func (a *redfishAccessDetails) NeedsMAC() bool {
 }
 
 func (a *redfishAccessDetails) Driver() string {
-	if a.isiDrac {
-		return "idrac"
-	}
 	return "redfish"
 }
 
@@ -98,41 +98,53 @@ func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]inter
 
 // That can be either pxe or redfish-virtual-media
 func (a *redfishAccessDetails) BootInterface() string {
-	if a.isiDrac {
-		return "idrac-redfish-virtual-media"
-	}
-
-	if a.isVirtualMedia {
-		return "redfish-virtual-media"
-	}
-
 	return "ipxe"
 }
 
 func (a *redfishAccessDetails) ManagementInterface() string {
-	if a.isiDrac {
-		return "idrac-redfish"
-	}
 	return ""
 }
 
 func (a *redfishAccessDetails) PowerInterface() string {
-	if a.isiDrac {
-		return "idrac-redfish"
-	}
 	return ""
 }
 
 func (a *redfishAccessDetails) RAIDInterface() string {
-	if a.isiDrac {
-		return "no-raid"
-	}
 	return ""
 }
 
 func (a *redfishAccessDetails) VendorInterface() string {
-	if a.isiDrac {
-		return "no-vendor"
-	}
 	return ""
+}
+
+// Virtual Media Overrides
+
+func (a *redfishVirtualMediaAccessDetails) BootInterface() string {
+	return "redfish-virtual-media"
+}
+
+// iDrac Virtual Media Overrides
+
+func (a *redfishiDracVirtualMediaAccessDetails) Driver() string {
+	return "idrac"
+}
+
+func (a *redfishiDracVirtualMediaAccessDetails) BootInterface() string {
+	return "idrac-redfish-virtual-media"
+}
+
+func (a *redfishiDracVirtualMediaAccessDetails) ManagementInterface() string {
+	return "idrac-redfish"
+}
+
+func (a *redfishiDracVirtualMediaAccessDetails) PowerInterface() string {
+	return "idrac-redfish"
+}
+
+func (a *redfishiDracVirtualMediaAccessDetails) RAIDInterface() string {
+	return "no-raid"
+}
+
+func (a *redfishiDracVirtualMediaAccessDetails) VendorInterface() string {
+	return "no-vendor"
 }

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -22,9 +22,8 @@ func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 }
 
 func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
-	bmcType := strings.Replace(parsedURL.Scheme, "+virtualmedia", "", 1)
 	return &redfishAccessDetails{
-		bmcType:        bmcType,
+		bmcType:        parsedURL.Scheme,
 		host:           parsedURL.Host,
 		path:           parsedURL.Path,
 		isVirtualMedia: true,

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -87,5 +87,5 @@ func (a *redfishAccessDetails) BootInterface() string {
 		return "redfish-virtual-media"
 	}
 
-	return "pxe"
+	return "ipxe"
 }

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -9,8 +9,8 @@ func init() {
 	registerFactory("redfish", newRedfishAccessDetails)
 	registerFactory("redfish+http", newRedfishAccessDetails)
 	registerFactory("redfish+https", newRedfishAccessDetails)
-	registerFactory("redfish+virtualmedia", newRedfishVirtualMediaAccessDetails)
-	registerFactory("ilo5+virtualmedia", newRedfishVirtualMediaAccessDetails)
+	registerFactory("redfish-virtualmedia", newRedfishVirtualMediaAccessDetails)
+	registerFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails)
 }
 
 func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -89,3 +89,19 @@ func (a *redfishAccessDetails) BootInterface() string {
 
 	return "ipxe"
 }
+
+func (a *redfishAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *redfishAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *redfishAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *redfishAccessDetails) VendorInterface() string {
+	return ""
+}

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -10,6 +10,7 @@ func init() {
 	registerFactory("redfish+http", newRedfishAccessDetails)
 	registerFactory("redfish+https", newRedfishAccessDetails)
 	registerFactory("redfish+virtualmedia", newRedfishVirtualMediaAccessDetails)
+	registerFactory("ilo5+virtualmedia", newRedfishVirtualMediaAccessDetails)
 }
 
 func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -9,6 +9,7 @@ func init() {
 	registerFactory("redfish", newRedfishAccessDetails)
 	registerFactory("redfish+http", newRedfishAccessDetails)
 	registerFactory("redfish+https", newRedfishAccessDetails)
+	registerFactory("redfish+virtualmedia", newRedfishVirtualMediaAccessDetails)
 }
 
 func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
@@ -19,10 +20,21 @@ func newRedfishAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
 	}, nil
 }
 
+func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL) (AccessDetails, error) {
+	bmcType := strings.Replace(parsedURL.Scheme, "+virtualmedia", "", 1)
+	return &redfishAccessDetails{
+		bmcType:        bmcType,
+		host:           parsedURL.Host,
+		path:           parsedURL.Path,
+		isVirtualMedia: true,
+	}, nil
+}
+
 type redfishAccessDetails struct {
-	bmcType string
-	host    string
-	path    string
+	bmcType        string
+	host           string
+	path           string
+	isVirtualMedia bool
 }
 
 const redfishDefaultScheme = "https"
@@ -71,5 +83,9 @@ func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]inter
 
 // That can be either pxe or redfish-virtual-media
 func (a *redfishAccessDetails) BootInterface() string {
+	if a.isVirtualMedia {
+		return "redfish-virtual-media"
+	}
+
 	return "pxe"
 }

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -240,10 +240,15 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged bool) (r
 		ironicNode, err = nodes.Create(
 			p.client,
 			nodes.CreateOpts{
-				Driver:        p.bmcAccess.Driver(),
-				BootInterface: p.bmcAccess.BootInterface(),
-				Name:          p.host.Name,
-				DriverInfo:    driverInfo,
+				Driver:              p.bmcAccess.Driver(),
+				BootInterface:       p.bmcAccess.BootInterface(),
+				Name:                p.host.Name,
+				DriverInfo:          driverInfo,
+				InspectInterface:    "inspector",
+				ManagementInterface: p.bmcAccess.ManagementInterface(),
+				PowerInterface:      p.bmcAccess.PowerInterface(),
+				RAIDInterface:       p.bmcAccess.RAIDInterface(),
+				VendorInterface:     p.bmcAccess.VendorInterface(),
 			}).Extract()
 		// FIXME(dhellmann): Handle 409 and 503? errors here.
 		if err != nil {


### PR DESCRIPTION
This cherry-picks the features that enable management of virtual media for Redfish, iLO5, and iDRAC to OpenShift 4.3 release branch of baremetal-operator.