### PR TITLE
Bug 1807854 : Don't assume IPv4 in introspection data

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -475,13 +475,16 @@ func getNICDetails(ifdata []introspection.InterfaceType,
 	for i, intf := range ifdata {
 		baseIntf := basedata[intf.Name]
 		vlans, vlanid := getVLANs(baseIntf)
-
+		ip := intf.IPV4Address
+		if ip == "" {
+			ip = intf.IPV6Address
+		}
 		nics[i] = metal3v1alpha1.NIC{
 			Name: intf.Name,
 			Model: strings.TrimLeft(fmt.Sprintf("%s %s",
 				intf.Vendor, intf.Product), " "),
 			MAC:       intf.MACAddress,
-			IP:        intf.IPV4Address,
+			IP:        ip,
 			VLANs:     vlans,
 			VLANID:    vlanid,
 			SpeedGbps: getNICSpeedGbps(extradata[intf.Name]),

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -332,8 +332,14 @@ func TestGetVLANsMalformed(t *testing.T) {
 func TestGetNICDetails(t *testing.T) {
 	nics := getNICDetails(
 		[]introspection.InterfaceType{
-			introspection.InterfaceType{Name: "eth0", MACAddress: "00:11:22:33:44:55"},
-			introspection.InterfaceType{Name: "eth1", MACAddress: "66:77:88:99:aa:bb"},
+			introspection.InterfaceType{
+				Name: "eth0",
+				IPV4Address: "192.0.2.1",
+				MACAddress: "00:11:22:33:44:55"},
+			introspection.InterfaceType{
+				Name: "eth1",
+				IPV6Address: "2001:db8::1",
+				MACAddress: "66:77:88:99:aa:bb"},
 		},
 		map[string]introspection.BaseInterfaceType{
 			"eth0": introspection.BaseInterfaceType{
@@ -360,6 +366,7 @@ func TestGetNICDetails(t *testing.T) {
 	if (!reflect.DeepEqual(nics[0], metal3v1alpha1.NIC{
 		Name: "eth0",
 		MAC:  "00:11:22:33:44:55",
+		IP:   "192.0.2.1",
 		PXE:  true,
 		VLANs: []metal3v1alpha1.VLAN{
 			metal3v1alpha1.VLAN{ID: 1},
@@ -371,6 +378,7 @@ func TestGetNICDetails(t *testing.T) {
 	if (!reflect.DeepEqual(nics[1], metal3v1alpha1.NIC{
 		Name:      "eth1",
 		MAC:       "66:77:88:99:aa:bb",
+		IP:        "2001:db8::1",
 		SpeedGbps: 1,
 	})) {
 		t.Errorf("Unexpected NIC data")


### PR DESCRIPTION
This can be one of two keys, depending on whether the host
got an ipv4 or ipv6 address, so use the ipv6 key in the case
where the ipv4 one is unset.

Currently in a single-stack ipv6 deployment the IP ends up
empty like:

Hostname:     worker-0.ostest.test.metalkube.org
    Nics:
      Ip:

But with this change Ip should be correctly populated.

Cherry-Pick of https://github.com/metal3-io/baremetal-operator/pull/457