### PR TITLE
[WIP] Retry when inspection failed

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -176,7 +176,7 @@ func (p *ironicProvisioner) findExistingHost() (ironicNode *nodes.Node, err erro
 		ironicNode, err = nodes.Get(p.client, p.status.ID).Extract()
 		switch err.(type) {
 		case nil:
-			p.log.Info("found existing node by ID")
+			p.log.Info("found existing node by ID", "state", ironicNode.ProvisionState, "last_error", ironicNode.LastError)
 			return ironicNode, nil
 		case gophercloud.ErrDefault404:
 		default:
@@ -190,7 +190,7 @@ func (p *ironicProvisioner) findExistingHost() (ironicNode *nodes.Node, err erro
 	ironicNode, err = nodes.Get(p.client, p.host.Name).Extract()
 	switch err.(type) {
 	case nil:
-		p.log.Info("found existing node by name")
+		p.log.Info("found existing node by name", "state", ironicNode.ProvisionState, "last_error", ironicNode.LastError)
 		return ironicNode, nil
 	case gophercloud.ErrDefault404:
 		return nil, nil

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -596,6 +596,18 @@ func (p *ironicProvisioner) InspectHardware() (result provisioner.Result, detail
 				result.RequeueAfter = introspectionRequeueDelay
 				err = nil
 				return
+			case nodes.InspectFail:
+				p.log.Info("inspection failed, will retry", "error", ironicNode.LastError)
+				result, err = p.changeNodeProvisionState(
+					ironicNode,
+					nodes.ProvisionStateOpts{Target: nodes.TargetManage},
+				)
+				if err == nil {
+					result.Dirty = true
+					result.RequeueAfter = introspectionRequeueDelay
+				}
+
+				return
 			default:
 				p.log.Info("starting new hardware inspection")
 				result, err = p.changeNodeProvisionState(


### PR DESCRIPTION
In order to retry if inspection failed, we need to move the host back to
manageable and retry inspection.

We're seeing in CI that some high percentage of runs, something around 25%, fail to bring up a worker.  We think there's some kind of race that's still being investigated, but regardless the BMO needs to recover from failure better. If a node fails inspection, BMO will never try to recover.
