### PR TITLE
Bug 1826418: Add openstack profile to BMO

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -161,6 +161,7 @@ details, etc.
   | `libvirt`           | /dev/vda        |
   | `dell`              | HCTL: 0:0:0:0   |
   | `dell-raid`         | HCTL: 0:2:0:0   |
+  | `openstack`         | /dev/vdb        |
 
   **NOTE:** These are subject to change.
 

--- a/pkg/hardware/profile.go
+++ b/pkg/hardware/profile.go
@@ -85,6 +85,16 @@ func init() {
 		LocalGB: 50,
 		CPUArch: "x86_64",
 	}
+	
+	profiles["openstack"] = Profile{
+		Name: "openstack",
+		RootDeviceHints: RootDeviceHints{
+			DeviceName: "/dev/vdb",
+		},
+		RootGB:  10,
+		LocalGB: 50,
+		CPUArch: "x86_64",
+	}
 
 }
 


### PR DESCRIPTION
This is a cherry pick of PR# 486 upstream

OCP Baremetal IPI inside of Openstack environment requires the RootDeviceHint to be /dev/vdb when a pxeboot is performed given that OSP uses nova rescue and a pxeboot.img as /dev/vda.