### PR TITLE
Bug 1838570: Use -mod=vendor when building tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ build:
 .PHONY: tools
 tools:
 	@echo LDFLAGS=$(LDFLAGS)
-	go build -o build/_output/bin/get-hardware-details cmd/get-hardware-details/main.go
+	go build -mod=vendor -o build/_output/bin/get-hardware-details cmd/get-hardware-details/main.go
 
 .PHONY: deploy
 deploy:


### PR DESCRIPTION
Similar to #60 -- we need to use `-mod=vedor` when building tools.

Downstream jobs can't access the internet at build time, and therefore
we're vendoring all Go dependencies. In order to actually build the
binary without attempting to download modules from the internet, we have
to set the -mod flag to vendor.

According to the go build documentation:

"To build using the main module's top-level vendor directory to satisfy
dependencies (disabling use of the usual network sources and local
caches), use 'go build -mod=vendor'."