### PR TITLE
Merge upstream 2020-06-17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ docker-golint:
 .PHONY: build
 build: ## Build the operator binary
 	@echo LDFLAGS=$(LDFLAGS)
-	go build -mod=vendor -ldflags $(LDFLAGS) -o build/_output/bin/baremetal-operator cmd/manager/main.go
+	go build -ldflags $(LDFLAGS) -o build/_output/bin/baremetal-operator cmd/manager/main.go
 
 .PHONY: tools
 tools:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/metal3-io/baremetal-operator
 COPY . .
 RUN make build

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,13 +1,13 @@
-# Running Bare Metal Operator with/without Ironic
+# Running Bare Metal Operator with or without Ironic
 
 This document explains the deployment scenarios of deploying Bare Metal
-Operator(BMO) with/without Ironic.
+Operator(BMO) with or without Ironic as well as deploying only Ironic scenario.
 
 **These are the deployment use cases in this document:**
 
-1. Deploying baremetal operator with Ironic.
+1. Deploying baremetal-operator with Ironic.
 
-2. Deploying baremetal operator without Ironic.
+2. Deploying baremetal-operator without Ironic.
 
 3. Deploying only Ironic.
 
@@ -20,8 +20,9 @@ deploy/
 │   ├── kustomization.yaml
 │   └── metal3.io_baremetalhosts_crd.yaml
 ├── default
-│   ├── ironic_bmo_configmap.env
-│   └── kustomization.yaml
+│   ├── ironic_bmo_configmap.env
+│   ├── kustomization.yaml
+│   └── kustomizeconfig.yaml
 ├── ironic_ci.env
 ├── namespace
 │   ├── kustomization.yaml
@@ -37,10 +38,11 @@ deploy/
 └── role.yaml -> rbac/role.yaml
 ```
 
-The `deploy` directory has one top level folder for deployment,
-namely `default` and it deploys only baremetal operator through kustomization.
-In addition, `crds`, `namespace` and `rbac` folders have their own kustomization
-and yaml files.
+The `deploy` directory has one top level folder for deployment, namely `default`
+and it deploys only baremetal-operator through kustomization file calling
+`operator` folder, and also uses kustomization config file for teaching
+kustomize where to look at when substituting variables. In addition, `crds`,
+`namespace` and `rbac` folders have their own kustomization and yaml files.
 
 ## Current structure of ironic-deployment directory
 
@@ -67,14 +69,14 @@ through kustomization.
 The user should run following commands to be able to meet requirements of each
 use case as provided below:
 
-### Commands to deploy baremetal operator with Ironic
+### Commands to deploy baremetal-operator with Ironic
 
 ```diff
 kustomize build $BMOPATH/deploy/default | kubectl apply -f-
 kustomize build $BMOPATH/ironic-deployment/default | kubectl apply -f-
 ```
 
-### Command to deploy baremetal operator without Ironic
+### Command to deploy baremetal-operator without Ironic
 
 ```diff
 kustomize build $BMOPATH/deploy/default | kubectl apply -f-

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator
 
-go 1.13
+go 1.14
 
 require (
 	github.com/go-logr/logr v0.1.0

--- a/hack/Dockerfile.golint
+++ b/hack/Dockerfile.golint
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.13
+FROM registry.hub.docker.com/library/golang:1.14
 
 RUN go get -u golang.org/x/lint/golint
 

--- a/hack/Dockerfile.operator-sdk
+++ b/hack/Dockerfile.operator-sdk
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.13
+FROM registry.hub.docker.com/library/golang:1.14
 
 ENV SDK_VERSION=v0.17.0
 ENV SDK_BIN=/sdkbin

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,6 +31,7 @@ github.com/evanphx/json-patch
 # github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 github.com/ghodss/yaml
 # github.com/go-logr/logr v0.1.0
+## explicit
 github.com/go-logr/logr
 # github.com/go-logr/zapr v0.1.1
 github.com/go-logr/zapr
@@ -39,15 +40,18 @@ github.com/go-openapi/jsonpointer
 # github.com/go-openapi/jsonreference v0.19.3
 github.com/go-openapi/jsonreference
 # github.com/go-openapi/spec v0.19.4
+## explicit
 github.com/go-openapi/spec
 # github.com/go-openapi/swag v0.19.5
 github.com/go-openapi/swag
 # github.com/gobuffalo/envy v1.7.1
+## explicit
 github.com/gobuffalo/envy
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
+## explicit
 github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.3.2
 github.com/golang/protobuf/proto
@@ -62,6 +66,7 @@ github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/google/gofuzz v1.1.0
+## explicit
 github.com/google/gofuzz
 # github.com/google/uuid v1.1.1
 github.com/google/uuid
@@ -70,6 +75,7 @@ github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/gophercloud/gophercloud v0.6.0
+## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/baremetal/noauth
@@ -83,9 +89,11 @@ github.com/gophercloud/gophercloud/openstack/identity/v3/tokens
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/hashicorp/golang-lru v0.5.4
+## explicit
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/imdario/mergo v0.3.8
+## explicit
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
@@ -109,7 +117,12 @@ github.com/mitchellh/go-homedir
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
+# github.com/onsi/ginkgo v1.12.0
+## explicit
+# github.com/onsi/gomega v1.9.0
+## explicit
 # github.com/operator-framework/operator-sdk v0.17.0
+## explicit
 github.com/operator-framework/operator-sdk/internal/scaffold
 github.com/operator-framework/operator-sdk/internal/scaffold/input
 github.com/operator-framework/operator-sdk/internal/scaffold/internal/deps
@@ -122,10 +135,12 @@ github.com/operator-framework/operator-sdk/version
 # github.com/pborman/uuid v1.2.0
 github.com/pborman/uuid
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.5.1
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -149,10 +164,12 @@ github.com/sirupsen/logrus
 github.com/spf13/afero
 github.com/spf13/afero/mem
 # github.com/spf13/cobra v0.0.6
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 # go.uber.org/atomic v1.6.0
 go.uber.org/atomic
@@ -166,11 +183,15 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
+## explicit
 golang.org/x/crypto/ssh/terminal
+# golang.org/x/lint v0.0.0-20200302205851-738671d3881b
+## explicit
 # golang.org/x/mod v0.2.0
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20200301022130-244492dfa37a
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -178,6 +199,7 @@ golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
@@ -195,6 +217,7 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200430192856-2840dafb9ee1
+## explicit
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/imports
 golang.org/x/tools/internal/event
@@ -228,6 +251,7 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
 # k8s.io/api v0.17.4
+## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -275,6 +299,7 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 # k8s.io/apimachinery v0.17.4
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -321,6 +346,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.17.4
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached
 k8s.io/client-go/discovery/cached/memory
@@ -407,14 +433,17 @@ k8s.io/client-go/util/workqueue
 # k8s.io/klog v1.0.0
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
+## explicit
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # sigs.k8s.io/controller-runtime v0.5.2
+## explicit
 sigs.k8s.io/controller-runtime/pkg/cache
 sigs.k8s.io/controller-runtime/pkg/cache/internal
 sigs.k8s.io/controller-runtime/pkg/client
@@ -451,4 +480,9 @@ sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/certwatcher
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
+# github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible
+# k8s.io/client-go => k8s.io/client-go v0.17.4
+# github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
+# github.com/openshift/api => github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad


### PR DESCRIPTION
There are a couple of commits on top of the merge:

* Updating the vendor directory to work with golang 1.14 (automatic change)
* Removing the `-mod=vendor` flag from the build command

This solves the same problem as #76 but it's more elegant. Golang 1.14 introduces new defaults that make the `mod` flag unnecessary in our scenario (both upstream and downstream).