### PR TITLE
Bug 1851530: Don't write status annotation

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -832,10 +832,11 @@ func saveHostProvisioningSettings(host *metal3v1alpha1.BareMetalHost) (dirty boo
 	return
 }
 
-func (r *ReconcileBareMetalHost) saveHostStatus(host *metal3v1alpha1.BareMetalHost) error {
+func (r *ReconcileBareMetalHost) saveHostStatus(host *metal3v1alpha1.BareMetalHost) (err error) {
 	t := metav1.Now()
 	host.Status.LastUpdated = &t
 
+	/* Don't save the Host annotation - this is buggy and we don't need it.
 	if err := r.saveHostAnnotation(host); err != nil {
 		return err
 	}
@@ -853,6 +854,7 @@ func (r *ReconcileBareMetalHost) saveHostStatus(host *metal3v1alpha1.BareMetalHo
 		return errors.Wrap(err, "Failed to update Status annotation")
 	}
 	host.Status = *obj
+	*/
 	err = r.client.Status().Update(context.TODO(), host)
 	return err
 }

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -4,7 +4,6 @@ import (
 	goctx "context"
 	"encoding/base64"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -279,6 +278,7 @@ func TestStatusAnnotation_Partial(t *testing.T) {
 	)
 }
 
+/* We are not saving the Host annotation - it is buggy and we don't need it.
 // TestStatusAnnotation tests if statusAnnotation is populated correctly
 func TestStatusAnnotation(t *testing.T) {
 	host := newDefaultHost(t)
@@ -309,6 +309,7 @@ func TestStatusAnnotation(t *testing.T) {
 	)
 
 }
+*/
 
 // TestPause ensures that the requeue happens when the pause annotation is there.
 func TestPause(t *testing.T) {


### PR DESCRIPTION
The code to write a status annotation can get stuck in an infinite hot
loop, and the upstream fix to it seems highly prone to further issues.

We don't need (or want) to write a status annotation in OpenShift
(though we do need to be able to read one), so disable the offending
code.

https://bugzilla.redhat.com/show_bug.cgi?id=1851530