### PR TITLE
Sync downstream 20200716

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -290,8 +290,11 @@ func TestPause(t *testing.T) {
 
 	tryReconcile(t, r, host,
 		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
-			if result.Requeue && result.RequeueAfter == pauseRetryDelay &&
-				len(host.Finalizers) == 0 {
+			// Because the host is created with the annotation, we
+			// expect it to never have any reconciling done at all, so
+			// it has no finalizer.
+			t.Logf("requeue: %v  finalizers: %v", result.Requeue, host.Finalizers)
+			if !result.Requeue && len(host.Finalizers) == 0 {
 				return true
 			}
 			return false


### PR DESCRIPTION
This PR includes a few changes to behavior for syncing hosts that are paused or that have errors. It also includes a change to not update a host when the power state matches the desired state, so that the host is not constantly being reconciled twice per minute.