### PR TITLE
Bug 1851532: Do not write status annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,20 +67,24 @@ crd_file=deploy/crds/metal3.io_baremetalhosts_crd.yaml
 crd_tmp=.crd.yaml.tmp
 
 .PHONY: lint
-lint: test-sec $GOPATH/bin/golint
+lint: test-sec $(GOPATH)/bin/golint
 	find ./pkg ./cmd -type f -name \*.go  |grep -v zz_ | xargs -L1 golint -set_exit_status
 	go vet ./pkg/... ./cmd/...
 	cp $(crd_file) $(crd_tmp); make generate; if ! diff -q $(crd_file) $(crd_tmp); then mv $(crd_tmp) $(crd_file); exit 1; else rm $(crd_tmp); fi
 
 .PHONY: test-sec
-test-sec: $GOPATH/bin/gosec
+test-sec: $(GOPATH)/bin/gosec
 	gosec -severity medium --confidence medium -quiet ./...
 
-$GOPATH/bin/gosec:
-	go get -u github.com/securego/gosec/cmd/gosec
+$(GOPATH)/bin/gosec:
+	go get -d golang.org/x/tools/go/packages
+	cd $(GOPATH)/src/golang.org/x/tools/go/packages; git checkout 8f9ed77dd8e51636de1225a7e25cf48778b97060^
+	go get -d github.com/securego/gosec/cmd/gosec
+	cd $(GOPATH)/src/github.com/securego/gosec/cmd/gosec; git checkout v2.3.0
+	go get github.com/securego/gosec/cmd/gosec
 
-$GOPATH/bin/golint:
-	go get -u golang.org/x/lint/golint
+$(GOPATH)/bin/golint:
+	go get golang.org/x/lint/golint
 
 .PHONY: docs
 docs: $(patsubst %.dot,%.png,$(wildcard docs/*.dot))

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -187,19 +187,19 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 			}
 			errStatus := r.client.Status().Update(context.TODO(), host)
 			if errStatus != nil {
-				return reconcile.Result{}, errors.Wrap(err, "Could not restore status from annotation")
+				return reconcile.Result{}, errors.Wrap(errStatus, "Could not restore status from annotation")
 			}
 			return reconcile.Result{Requeue: true}, nil
 		}
 		reqLogger.Info("No status cache found")
 	} else {
-		//The status annotation is unneeded, as the status is present, and it will get outdated, so removing it
-		objStatus, err := r.getHostStatusFromAnnotation(host)
-		if err == nil && objStatus != nil {
+		// The status annotation is unneeded, as the status subresource is
+		// already present. The annotation data will get outdated, so remove it.
+		if _, present := annotations[metal3v1alpha1.StatusAnnotation]; present {
 			delete(annotations, metal3v1alpha1.StatusAnnotation)
 			errStatus := r.client.Update(context.TODO(), host)
 			if errStatus != nil {
-				return reconcile.Result{}, errors.Wrap(err, "Could not delete status annotation")
+				return reconcile.Result{}, errors.Wrap(errStatus, "Could not delete status annotation")
 			}
 			return reconcile.Result{Requeue: true}, nil
 		}

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -170,6 +169,8 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 		return reconcile.Result{}, errors.Wrap(err, "could not load host data")
 	}
 
+	annotations := host.GetAnnotations()
+
 	// Check if Status is empty and status annotation is present
 	// Manually restore data.
 	if !r.hostHasStatus(host) {
@@ -191,6 +192,17 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 			return reconcile.Result{Requeue: true}, nil
 		}
 		reqLogger.Info("No status cache found")
+	} else {
+		//The status annotation is unneeded, as the status is present, and it will get outdated, so removing it
+		objStatus, err := r.getHostStatusFromAnnotation(host)
+		if err == nil && objStatus != nil {
+			delete(annotations, metal3v1alpha1.StatusAnnotation)
+			errStatus := r.client.Update(context.TODO(), host)
+			if errStatus != nil {
+				return reconcile.Result{}, errors.Wrap(err, "Could not delete status annotation")
+			}
+			return reconcile.Result{Requeue: true}, nil
+		}
 	}
 
 	// NOTE(dhellmann): Handle a few steps outside of the phase
@@ -259,13 +271,10 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 		info.log.Info("saving host status",
 			"operational status", host.OperationalStatus(),
 			"provisioning state", host.Status.Provisioning.State)
-		requeueNeeded, err := r.saveHostStatus(host)
+		err := r.saveHostStatus(host)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err,
 				fmt.Sprintf("failed to save host status after %q", initialState))
-		}
-		if requeueNeeded {
-			return reconcile.Result{Requeue: true}, nil
 		}
 		info.log.Info("Updated Status")
 
@@ -329,8 +338,8 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 			// overwrites our discovered state
 			host.Status.ErrorMessage = err.Error()
 			host.Status.ErrorType = ""
-			requeueNeeded, saveErr := r.saveHostStatus(host)
-			if saveErr != nil || requeueNeeded {
+			saveErr := r.saveHostStatus(host)
+			if saveErr != nil {
 				return reconcile.Result{Requeue: true}, saveErr
 			}
 			// Only publish the event if we do not have an error
@@ -344,13 +353,11 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 	// at some point in the future.
 	case *ResolveBMCSecretRefError:
 		credentialsMissing.Inc()
-		changed, requeue, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
+		changed, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
 		if saveErr != nil {
 			return reconcile.Result{Requeue: true}, saveErr
 		} else if !changed {
 			return reconcile.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
-		} else if requeue {
-			return reconcile.Result{Requeue: true}, nil
 		}
 		// Only publish the event if we do not have an error
 		// after saving the first time so that we only publish one time, requeue immediately to save the status
@@ -363,13 +370,11 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 	// the host to be reconciled again
 	case *bmc.CredentialsValidationError, *bmc.UnknownBMCTypeError:
 		credentialsInvalid.Inc()
-		changed, requeue, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
+		changed, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
 		if saveErr != nil {
 			return reconcile.Result{Requeue: true}, saveErr
 		} else if !changed {
 			return reconcile.Result{}, nil
-		} else if requeue {
-			return reconcile.Result{Requeue: true}, nil
 		}
 		// Only publish the event if we do not have an error
 		// after saving so that we only publish one time. Requeue immediately to save the status
@@ -728,61 +733,11 @@ func (r *ReconcileBareMetalHost) actionManageReady(prov provisioner.Provisioner,
 	return r.manageHostPower(prov, info)
 }
 
-func (r *ReconcileBareMetalHost) saveHostStatus(host *metal3v1alpha1.BareMetalHost) (bool, error) {
+func (r *ReconcileBareMetalHost) saveHostStatus(host *metal3v1alpha1.BareMetalHost) error {
 	t := metav1.Now()
 	host.Status.LastUpdated = &t
 
-	if err := r.saveHostAnnotation(host); err != nil {
-		if k8serrors.IsConflict(err) {
-			log.Info("Failed to update status annotation because of a conflict, requeuing", "host", host.Name)
-			return true, nil
-		}
-		return false, errors.Wrap(err, "Failed to update Status annotation")
-	}
-
-	if err := r.client.Status().Update(context.TODO(), host); err != nil {
-		if k8serrors.IsConflict(err) {
-			log.Info("Failed to update status because of a conflict, requeuing", "host", host.Name)
-			return true, nil
-		}
-		return false, errors.Wrap(err, "Failed to update Status")
-	}
-	return false, nil
-}
-
-func (r *ReconcileBareMetalHost) saveHostAnnotation(host *metal3v1alpha1.BareMetalHost) error {
-	//Repopulate annotation again
-	objStatus, err := r.getHostStatusFromAnnotation(host)
-	if err != nil {
-		return err
-	}
-
-	if objStatus != nil {
-		// These values are copied to avoid continually updating the annotation
-		objStatus.LastUpdated = host.Status.LastUpdated
-		objStatus.OperationHistory = host.Status.OperationHistory
-		if reflect.DeepEqual(host.Status, *objStatus) {
-			return nil
-		}
-	}
-
-	newAnnotation, err := marshalStatusAnnotation(&host.Status)
-	if err != nil {
-		return err
-	}
-	if host.Annotations == nil {
-		host.Annotations = make(map[string]string)
-	}
-	host.Annotations[metal3v1alpha1.StatusAnnotation] = string(newAnnotation)
-	return r.client.Update(context.TODO(), host.DeepCopy())
-}
-
-func marshalStatusAnnotation(status *metal3v1alpha1.BareMetalHostStatus) ([]byte, error) {
-	newAnnotation, err := json.Marshal(status)
-	if err != nil {
-		return []byte{}, errors.Wrap(err, "failed to marshall status annotation")
-	}
-	return newAnnotation, nil
+	return r.client.Status().Update(context.TODO(), host)
 }
 
 func unmarshalStatusAnnotation(content []byte) (*metal3v1alpha1.BareMetalHostStatus, error) {
@@ -807,7 +762,7 @@ func (r *ReconcileBareMetalHost) getHostStatusFromAnnotation(host *metal3v1alpha
 	return objStatus, nil
 }
 
-func (r *ReconcileBareMetalHost) setErrorCondition(request reconcile.Request, host *metal3v1alpha1.BareMetalHost, errType metal3v1alpha1.ErrorType, message string) (changed, requeue bool, err error) {
+func (r *ReconcileBareMetalHost) setErrorCondition(request reconcile.Request, host *metal3v1alpha1.BareMetalHost, errType metal3v1alpha1.ErrorType, message string) (changed bool, err error) {
 	reqLogger := log.WithValues("Request.Namespace",
 		request.Namespace, "Request.Name", request.Name)
 
@@ -818,7 +773,7 @@ func (r *ReconcileBareMetalHost) setErrorCondition(request reconcile.Request, ho
 			"message", message,
 		)
 		// We might need to requeue if we failed to update the status
-		requeue, err = r.saveHostStatus(host)
+		err = r.saveHostStatus(host)
 		if err != nil {
 			err = errors.Wrap(err, "failed to update error message")
 		}

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -271,12 +271,11 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 		info.log.Info("saving host status",
 			"operational status", host.OperationalStatus(),
 			"provisioning state", host.Status.Provisioning.State)
-		err := r.saveHostStatus(host)
+		err = r.saveHostStatus(host)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err,
 				fmt.Sprintf("failed to save host status after %q", initialState))
 		}
-		info.log.Info("Updated Status")
 
 		for _, cb := range info.postSaveCallbacks {
 			cb()
@@ -356,13 +355,13 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 		changed, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
 		if saveErr != nil {
 			return reconcile.Result{Requeue: true}, saveErr
-		} else if !changed {
-			return reconcile.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
 		}
-		// Only publish the event if we do not have an error
-		// after saving the first time so that we only publish one time, requeue immediately to save the status
-		r.publishEvent(request, host.NewEvent("BMCCredentialError", err.Error()))
-		return reconcile.Result{Requeue: true}, nil
+		if changed {
+			// Only publish the event if we do not have an error
+			// after saving so that we only publish one time.
+			r.publishEvent(request, host.NewEvent("BMCCredentialError", err.Error()))
+		}
+		return reconcile.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
 	// If we have found the secret but it is missing the required fields
 	// or the BMC address is defined but malformed we set the
 	// host into an error state but we do not Requeue it
@@ -370,16 +369,14 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 	// the host to be reconciled again
 	case *bmc.CredentialsValidationError, *bmc.UnknownBMCTypeError:
 		credentialsInvalid.Inc()
-		changed, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
+		_, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
 		if saveErr != nil {
 			return reconcile.Result{Requeue: true}, saveErr
-		} else if !changed {
-			return reconcile.Result{}, nil
 		}
 		// Only publish the event if we do not have an error
-		// after saving so that we only publish one time. Requeue immediately to save the status
+		// after saving so that we only publish one time.
 		r.publishEvent(request, host.NewEvent("BMCCredentialError", err.Error()))
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{}, nil
 	default:
 		unhandledCredentialsError.Inc()
 		return reconcile.Result{}, errors.Wrap(err, "An unhandled failure occurred with the BMC secret")
@@ -772,7 +769,6 @@ func (r *ReconcileBareMetalHost) setErrorCondition(request reconcile.Request, ho
 			"adding error message",
 			"message", message,
 		)
-		// We might need to requeue if we failed to update the status
 		err = r.saveHostStatus(host)
 		if err != nil {
 			err = errors.Wrap(err, "failed to update error message")

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -259,10 +259,15 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 		info.log.Info("saving host status",
 			"operational status", host.OperationalStatus(),
 			"provisioning state", host.Status.Provisioning.State)
-		if err = r.saveHostStatus(host); err != nil {
+		requeueNeeded, err := r.saveHostStatus(host)
+		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err,
 				fmt.Sprintf("failed to save host status after %q", initialState))
 		}
+		if requeueNeeded {
+			return reconcile.Result{Requeue: true}, nil
+		}
+		info.log.Info("Updated Status")
 
 		for _, cb := range info.postSaveCallbacks {
 			cb()
@@ -324,8 +329,8 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 			// overwrites our discovered state
 			host.Status.ErrorMessage = err.Error()
 			host.Status.ErrorType = ""
-			saveErr := r.saveHostStatus(host)
-			if saveErr != nil {
+			requeueNeeded, saveErr := r.saveHostStatus(host)
+			if saveErr != nil || requeueNeeded {
 				return reconcile.Result{Requeue: true}, saveErr
 			}
 			// Only publish the event if we do not have an error
@@ -339,16 +344,18 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 	// at some point in the future.
 	case *ResolveBMCSecretRefError:
 		credentialsMissing.Inc()
-		changed, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
+		changed, requeue, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
 		if saveErr != nil {
 			return reconcile.Result{Requeue: true}, saveErr
+		} else if !changed {
+			return reconcile.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
+		} else if requeue {
+			return reconcile.Result{Requeue: true}, nil
 		}
-		if changed {
-			// Only publish the event if we do not have an error
-			// after saving so that we only publish one time.
-			r.publishEvent(request, host.NewEvent("BMCCredentialError", err.Error()))
-		}
-		return reconcile.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
+		// Only publish the event if we do not have an error
+		// after saving the first time so that we only publish one time, requeue immediately to save the status
+		r.publishEvent(request, host.NewEvent("BMCCredentialError", err.Error()))
+		return reconcile.Result{Requeue: true}, nil
 	// If we have found the secret but it is missing the required fields
 	// or the BMC address is defined but malformed we set the
 	// host into an error state but we do not Requeue it
@@ -356,14 +363,18 @@ func (r *ReconcileBareMetalHost) credentialsErrorResult(err error, request recon
 	// the host to be reconciled again
 	case *bmc.CredentialsValidationError, *bmc.UnknownBMCTypeError:
 		credentialsInvalid.Inc()
-		_, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
+		changed, requeue, saveErr := r.setErrorCondition(request, host, metal3v1alpha1.RegistrationError, err.Error())
 		if saveErr != nil {
 			return reconcile.Result{Requeue: true}, saveErr
+		} else if !changed {
+			return reconcile.Result{}, nil
+		} else if requeue {
+			return reconcile.Result{Requeue: true}, nil
 		}
 		// Only publish the event if we do not have an error
-		// after saving so that we only publish one time.
+		// after saving so that we only publish one time. Requeue immediately to save the status
 		r.publishEvent(request, host.NewEvent("BMCCredentialError", err.Error()))
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true}, nil
 	default:
 		unhandledCredentialsError.Inc()
 		return reconcile.Result{}, errors.Wrap(err, "An unhandled failure occurred with the BMC secret")
@@ -717,29 +728,26 @@ func (r *ReconcileBareMetalHost) actionManageReady(prov provisioner.Provisioner,
 	return r.manageHostPower(prov, info)
 }
 
-func (r *ReconcileBareMetalHost) saveHostStatus(host *metal3v1alpha1.BareMetalHost) error {
+func (r *ReconcileBareMetalHost) saveHostStatus(host *metal3v1alpha1.BareMetalHost) (bool, error) {
 	t := metav1.Now()
 	host.Status.LastUpdated = &t
 
 	if err := r.saveHostAnnotation(host); err != nil {
-		return err
+		if k8serrors.IsConflict(err) {
+			log.Info("Failed to update status annotation because of a conflict, requeuing", "host", host.Name)
+			return true, nil
+		}
+		return false, errors.Wrap(err, "Failed to update Status annotation")
 	}
 
-	//Refetch host again
-	obj := host.Status.DeepCopy()
-	err := r.client.Get(context.TODO(),
-		client.ObjectKey{
-			Name:      host.Name,
-			Namespace: host.Namespace,
-		},
-		host,
-	)
-	if err != nil {
-		return errors.Wrap(err, "Failed to update Status annotation")
+	if err := r.client.Status().Update(context.TODO(), host); err != nil {
+		if k8serrors.IsConflict(err) {
+			log.Info("Failed to update status because of a conflict, requeuing", "host", host.Name)
+			return true, nil
+		}
+		return false, errors.Wrap(err, "Failed to update Status")
 	}
-	host.Status = *obj
-	err = r.client.Status().Update(context.TODO(), host)
-	return err
+	return false, nil
 }
 
 func (r *ReconcileBareMetalHost) saveHostAnnotation(host *metal3v1alpha1.BareMetalHost) error {
@@ -750,14 +758,14 @@ func (r *ReconcileBareMetalHost) saveHostAnnotation(host *metal3v1alpha1.BareMet
 	}
 
 	if objStatus != nil {
-		// This value is copied to avoid continually updating the annotation
+		// These values are copied to avoid continually updating the annotation
 		objStatus.LastUpdated = host.Status.LastUpdated
+		objStatus.OperationHistory = host.Status.OperationHistory
 		if reflect.DeepEqual(host.Status, *objStatus) {
 			return nil
 		}
 	}
 
-	delete(host.Annotations, metal3v1alpha1.StatusAnnotation)
 	newAnnotation, err := marshalStatusAnnotation(&host.Status)
 	if err != nil {
 		return err
@@ -799,7 +807,7 @@ func (r *ReconcileBareMetalHost) getHostStatusFromAnnotation(host *metal3v1alpha
 	return objStatus, nil
 }
 
-func (r *ReconcileBareMetalHost) setErrorCondition(request reconcile.Request, host *metal3v1alpha1.BareMetalHost, errType metal3v1alpha1.ErrorType, message string) (changed bool, err error) {
+func (r *ReconcileBareMetalHost) setErrorCondition(request reconcile.Request, host *metal3v1alpha1.BareMetalHost, errType metal3v1alpha1.ErrorType, message string) (changed, requeue bool, err error) {
 	reqLogger := log.WithValues("Request.Namespace",
 		request.Namespace, "Request.Name", request.Name)
 
@@ -809,7 +817,8 @@ func (r *ReconcileBareMetalHost) setErrorCondition(request reconcile.Request, ho
 			"adding error message",
 			"message", message,
 		)
-		err = r.saveHostStatus(host)
+		// We might need to requeue if we failed to update the status
+		requeue, err = r.saveHostStatus(host)
 		if err != nil {
 			err = errors.Wrap(err, "failed to update error message")
 		}

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -3,8 +3,8 @@ package baremetalhost
 import (
 	goctx "context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -212,7 +212,7 @@ func TestStatusAnnotation_EmptyStatus(t *testing.T) {
 }
 
 // TestStatusAnnotation_StatusPresent tests that if status is present
-// status annotation is ignored.
+// status annotation is ignored and deleted.
 func TestStatusAnnotation_StatusPresent(t *testing.T) {
 	host := newDefaultHost(t)
 	host.Annotations = map[string]string{
@@ -226,7 +226,8 @@ func TestStatusAnnotation_StatusPresent(t *testing.T) {
 
 	tryReconcile(t, r, host,
 		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
-			if host.Status.HardwareProfile != "StatusProfile" && host.Status.Provisioning.Image.URL == "foo" {
+			_, found := host.Annotations[metal3v1alpha1.StatusAnnotation]
+			if host.Status.HardwareProfile != "StatusProfile" && host.Status.Provisioning.Image.URL == "foo" && !found {
 				return true
 			}
 			return false
@@ -246,7 +247,7 @@ func TestStatusAnnotation_Partial(t *testing.T) {
 		return
 	}
 	unpackedStatus.LastUpdated = nil
-	packedStatus, err := marshalStatusAnnotation(unpackedStatus)
+	packedStatus, err := json.Marshal(unpackedStatus)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -269,37 +270,6 @@ func TestStatusAnnotation_Partial(t *testing.T) {
 			return false
 		},
 	)
-}
-
-// TestStatusAnnotation tests if statusAnnotation is populated correctly
-func TestStatusAnnotation(t *testing.T) {
-	host := newDefaultHost(t)
-	host.Spec.Online = true
-	host.Spec.Image = &metal3v1alpha1.Image{URL: "foo", Checksum: "123"}
-	bmcSecret := newSecret(defaultSecretName, "User", "Pass")
-	r := newTestReconciler(host, bmcSecret)
-
-	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
-			if utils.StringInList(host.Finalizers, metal3v1alpha1.BareMetalHostFinalizer) {
-				return true
-			}
-			return false
-		},
-	)
-
-	tryReconcile(t, r, host,
-		func(host *metal3v1alpha1.BareMetalHost, result reconcile.Result) bool {
-			objStatus, _ := r.getHostStatusFromAnnotation(host)
-			objStatus.LastUpdated = host.Status.LastUpdated
-
-			if reflect.DeepEqual(host.Status, *objStatus) {
-				return true
-			}
-			return false
-		},
-	)
-
 }
 
 // TestAddFinalizers ensures that the finalizers for the host are

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -132,7 +132,9 @@ func tryReconcile(t *testing.T, r *ReconcileBareMetalHost, host *metal3v1alpha1.
 		// The FakeClient keeps a copy of the object we update, so we
 		// need to replace the one we have with the updated data in
 		// order to test it.
-		r.client.Get(goctx.TODO(), request.NamespacedName, host)
+		updatedHost := &metal3v1alpha1.BareMetalHost{}
+		r.client.Get(goctx.TODO(), request.NamespacedName, updatedHost)
+		updatedHost.DeepCopyInto(host)
 
 		if isDone(host, result) {
 			logger.Info("tryReconcile: loop done")


### PR DESCRIPTION
Writing a status annotation as well as the Status subresource could cause hot reconcile loops. It's not needed in any case in OpenShift, and has been removed from the baremetal-operator upstream as well.