### PR TITLE
Bug 1863033: keep the boot mode up to date

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -487,14 +487,6 @@ func (r *ReconcileBareMetalHost) actionRegistering(prov provisioner.Provisioner,
 		info.postSaveCallbacks = append(info.postSaveCallbacks, updatedCredentials.Inc)
 	}
 
-	// Make sure we have saved the current boot mode value.
-	bootMode := info.host.BootMode()
-	if bootMode != info.host.Status.Provisioning.BootMode {
-		info.log.Info("saving boot mode")
-		info.host.Status.Provisioning.BootMode = bootMode
-		return actionContinue{}
-	}
-
 	provResult, err := prov.ValidateManagementAccess(credsChanged)
 	if err != nil {
 		noManagementAccess.Inc()

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -253,8 +253,6 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged bool) (r
 	if ironicNode == nil {
 		p.log.Info("registering host in ironic")
 
-		bootMode := p.host.BootMode()
-
 		ironicNode, err = nodes.Create(
 			p.client,
 			nodes.CreateOpts{
@@ -268,7 +266,7 @@ func (p *ironicProvisioner) ValidateManagementAccess(credentialsChanged bool) (r
 				RAIDInterface:       p.bmcAccess.RAIDInterface(),
 				VendorInterface:     p.bmcAccess.VendorInterface(),
 				Properties: map[string]interface{}{
-					"capabilities": bootModeCapabilities[bootMode],
+					"capabilities": bootModeCapabilities[p.host.Status.Provisioning.BootMode],
 				},
 			}).Extract()
 		// FIXME(dhellmann): Handle 409 and 503? errors here.
@@ -805,7 +803,67 @@ func (p *ironicProvisioner) getUpdateOptsForNode(ironicNode *nodes.Node) (update
 		},
 	)
 
+	// boot_mode
+	op, value := buildCapabilitiesValue(ironicNode, p.host.Status.Provisioning.BootMode)
+	updates = append(
+		updates,
+		nodes.UpdateOperation{
+			Op:    op,
+			Path:  "/properties/capabilities",
+			Value: value,
+		},
+	)
+
 	return updates, nil
+}
+
+// We can't just replace the capabilities because we need to keep the
+// values provided by inspection. We can't replace only the boot_mode
+// because the API isn't fine-grained enough for that. So we have to
+// look at the existing value and modify it. This function
+// encapsulates the logic for building the value and knowing which
+// update operation to use with the results.
+func buildCapabilitiesValue(ironicNode *nodes.Node, bootMode metal3v1alpha1.BootMode) (op nodes.UpdateOp, value string) {
+
+	capabilities, ok := ironicNode.Properties["capabilities"]
+	if !ok {
+		// There is no existing capabilities value
+		return nodes.AddOp, bootModeCapabilities[bootMode]
+	}
+	existingCapabilities := capabilities.(string)
+
+	// The capabilities value is set, so we will want to replace it.
+	op = nodes.ReplaceOp
+
+	if existingCapabilities == "" {
+		// The existing value is empty so we can replace the whole
+		// thing.
+		value = bootModeCapabilities[bootMode]
+		return
+	}
+
+	if !strings.Contains(existingCapabilities, "boot_mode") {
+		// No boot_mode is set, append and return
+		value = fmt.Sprintf("%s,%s", existingCapabilities, bootModeCapabilities[bootMode])
+		return
+	}
+
+	// The capabilities value has format "var1:val1,var2:val2". We
+	// know that boot_mode is there but not what value it has.  There
+	// are only 2 values, so we can replace the "wrong" string with
+	// the right one without fully parsing the string. We may want to
+	// change this later when we have more boot modes.
+
+	var fromMode metal3v1alpha1.BootMode
+	if bootMode == metal3v1alpha1.UEFI {
+		fromMode = metal3v1alpha1.Legacy
+	} else {
+		fromMode = metal3v1alpha1.UEFI
+	}
+	value = strings.ReplaceAll(existingCapabilities,
+		bootModeCapabilities[fromMode], bootModeCapabilities[bootMode])
+
+	return
 }
 
 func (p *ironicProvisioner) startProvisioning(ironicNode *nodes.Node, hostConf provisioner.HostConfigData) (result provisioner.Result, err error) {

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -501,3 +501,96 @@ func (m *mockServer) start() *mockServer {
 func (m *mockServer) stop() {
 	m.server.Close()
 }
+
+func TestBuildCapabilitiesValue(t *testing.T) {
+
+	cases := []struct {
+		Scenario      string
+		Node          nodes.Node
+		Mode          metal3v1alpha1.BootMode
+		ExpectedValue string
+		ExpectedOp    nodes.UpdateOp
+	}{
+		{
+			Scenario:      "unset",
+			Node:          nodes.Node{},
+			Mode:          metal3v1alpha1.UEFI,
+			ExpectedValue: "boot_mode:uefi",
+			ExpectedOp:    nodes.AddOp,
+		},
+		{
+			Scenario: "empty",
+			Node: nodes.Node{
+				Properties: map[string]interface{}{
+					"capabilities": "",
+				},
+			},
+			Mode:          metal3v1alpha1.UEFI,
+			ExpectedValue: "boot_mode:uefi",
+			ExpectedOp:    nodes.ReplaceOp,
+		},
+		{
+			Scenario: "not-there",
+			Node: nodes.Node{
+				Properties: map[string]interface{}{
+					"capabilities": "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
+				},
+			},
+			Mode:          metal3v1alpha1.UEFI,
+			ExpectedValue: "cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true,boot_mode:uefi",
+			ExpectedOp:    nodes.ReplaceOp,
+		},
+		{
+			Scenario: "uefi-to-uefi",
+			Node: nodes.Node{
+				Properties: map[string]interface{}{
+					"capabilities": "boot_mode:uefi,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
+				},
+			},
+			Mode:          metal3v1alpha1.UEFI,
+			ExpectedValue: "boot_mode:uefi,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
+			ExpectedOp:    nodes.ReplaceOp,
+		},
+		{
+			Scenario: "bios-to-bios",
+			Node: nodes.Node{
+				Properties: map[string]interface{}{
+					"capabilities": "boot_mode:bios,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
+				},
+			},
+			Mode:          metal3v1alpha1.Legacy,
+			ExpectedValue: "boot_mode:bios,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
+			ExpectedOp:    nodes.ReplaceOp,
+		},
+		{
+			Scenario: "bios-to-uefi",
+			Node: nodes.Node{
+				Properties: map[string]interface{}{
+					"capabilities": "boot_mode:bios,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
+				},
+			},
+			Mode:          metal3v1alpha1.UEFI,
+			ExpectedValue: "boot_mode:uefi,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
+			ExpectedOp:    nodes.ReplaceOp,
+		},
+		{
+			Scenario: "uefi-to-bios",
+			Node: nodes.Node{
+				Properties: map[string]interface{}{
+					"capabilities": "boot_mode:uefi,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
+				},
+			},
+			Mode:          metal3v1alpha1.Legacy,
+			ExpectedValue: "boot_mode:bios,cpu_vt:true,cpu_aes:true,cpu_hugepages:true,cpu_hugepages_1g:true",
+			ExpectedOp:    nodes.ReplaceOp,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			actualOp, actualVal := buildCapabilitiesValue(&tc.Node, tc.Mode)
+			assert.Equal(t, tc.ExpectedOp, actualOp)
+			assert.Equal(t, tc.ExpectedValue, actualVal)
+		})
+	}
+}


### PR DESCRIPTION
Have the controller save the boot mode to the status field and use
that value in the provisioner.

Update the boot mode in ironic before provisioning.

(cherry picked from commit b4733a71c2584d7d6ff6a43bf3bc44f584f4572d)