### PR TITLE
Bug 1874599: Always delete found host from Ironic on deletion

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1075,7 +1075,7 @@ func (p *ironicProvisioner) Delete() (result provisioner.Result, err error) {
 	}
 
 	p.log.Info("host ready to be removed")
-	err = nodes.Delete(p.client, p.status.ID).ExtractErr()
+	err = nodes.Delete(p.client, ironicNode.UUID).ExtractErr()
 	switch err.(type) {
 	case nil:
 		p.log.Info("removed")


### PR DESCRIPTION
When we go to delete a node we look it up by either the UUID stored in
the Host or by name, but previously when we deleted it from Ironic we
only used the UUID from the Host. This meant if the Host UUID was empty
or didn't match, we would be stuck in a loop from which we could never
recover. We can't have it both ways; either a node found by name is the
one that matches and we should delete it, or it isn't and we should
report that the node cannot be found and thus the delete is complete.

It is not clear under what circumstances we end up in this state. It is
possible that it involves the node being discovered by Ironic before the
Host is created and then immediately deleted.

Treat a host matching by name as the one we are looking for, and delete
it regardless of whether we had already stored the node ID.

Fixes #482

(cherry picked from commit ad798720560e74b658f1c3aafd7437569f015a38)
(cherry picked from commit 389283db4b77230949c4638b292ad1c88a46a377)