### PR TITLE
Bug 1879284: Handle StateAvailable when we see it

### DIFF
--- a/pkg/controller/baremetalhost/host_state_machine.go
+++ b/pkg/controller/baremetalhost/host_state_machine.go
@@ -42,6 +42,7 @@ func (hsm *hostStateMachine) handlers() map[metal3v1alpha1.ProvisioningState]sta
 		metal3v1alpha1.StateInspecting:            hsm.handleInspecting,
 		metal3v1alpha1.StateExternallyProvisioned: hsm.handleExternallyProvisioned,
 		metal3v1alpha1.StateMatchProfile:          hsm.handleMatchProfile,
+		metal3v1alpha1.StateAvailable:             hsm.handleReady,
 		metal3v1alpha1.StateReady:                 hsm.handleReady,
 		metal3v1alpha1.StateProvisioning:          hsm.handleProvisioning,
 		metal3v1alpha1.StateProvisioningError:     hsm.handleProvisioningError,


### PR DESCRIPTION
In future we will rename StateReady to StateAvailable, but for now make
sure we correctly handle a Host with StateAvailable so that resources
modified by a future release continue to operate as expected after a
downgrade.

Upstream:  metal3-io#636