### PR TITLE
when creating the provisioner only NewAccessDetails() if we have bmc info

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -158,9 +158,13 @@ func newProvisionerWithSettings(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc
 
 func newProvisionerWithIronicClients(host *metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher, clientIronic *gophercloud.ServiceClient, clientInspector *gophercloud.ServiceClient) (*ironicProvisioner, error) {
 
-	bmcAccess, err := bmc.NewAccessDetails(host.Spec.BMC.Address, host.Spec.BMC.DisableCertificateVerification)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse BMC address information")
+	var bmcAccess bmc.AccessDetails
+	var err error
+	if host.HasBMCDetails() {
+		bmcAccess, err = bmc.NewAccessDetails(host.Spec.BMC.Address, host.Spec.BMC.DisableCertificateVerification)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse BMC address information")
+		}
 	}
 
 	// Ensure we have a microversion high enough to get the features

--- a/vendor/github.com/gophercloud/gophercloud/go.mod
+++ b/vendor/github.com/gophercloud/gophercloud/go.mod
@@ -1,5 +1,7 @@
 module github.com/gophercloud/gophercloud
 
+go 1.15
+
 require (
 	golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect


### PR DESCRIPTION

In the assisted installer, we don't currently have bmc details