### PR TITLE
Bug 1912701: Handle dual-stack configuration in inspection data

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -405,8 +405,9 @@ type NIC struct {
 	// +kubebuilder:validation:Pattern=`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`
 	MAC string `json:"mac"`
 
-	// The IP address of the interface. This will be an IPv4 address if one is
-	// present, and only an IPv6 address if there is no IPv4 address.
+	// The IP address of the interface. This will be an IPv4 or IPv6 address
+	// if one is present.  If both IPv4 and IPv6 addresses are present in a
+	// dual-stack environment, two nics will be output, one with each IP.
 	IP string `json:"ip"`
 
 	// The speed of the device in Gigabits per second

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -339,7 +339,7 @@ spec:
                       description: NIC describes one network interface on the host.
                       properties:
                         ip:
-                          description: The IP address of the interface. This will be an IPv4 address if one is present, and only an IPv6 address if there is no IPv4 address.
+                          description: The IP address of the interface. This will be an IPv4 or IPv6 address if one is present.  If both IPv4 and IPv6 addresses are present in a dual-stack environment, two nics will be output, one with each IP.
                           type: string
                         mac:
                           description: The device MAC address

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -337,7 +337,7 @@ spec:
                       description: NIC describes one network interface on the host.
                       properties:
                         ip:
-                          description: The IP address of the interface. This will be an IPv4 address if one is present, and only an IPv6 address if there is no IPv4 address.
+                          description: The IP address of the interface. This will be an IPv4 or IPv6 address if one is present.  If both IPv4 and IPv6 addresses are present in a dual-stack environment, two nics will be output, one with each IP.
                           type: string
                         mac:
                           description: The device MAC address

--- a/pkg/provisioner/ironic/hardwaredetails/hardwaredetails_test.go
+++ b/pkg/provisioner/ironic/hardwaredetails/hardwaredetails_test.go
@@ -159,6 +159,14 @@ func TestGetNICDetails(t *testing.T) {
 				Name:        "eth1",
 				IPV6Address: "2001:db8::1",
 				MACAddress:  "66:77:88:99:aa:bb"},
+			{
+				Name:        "eth46",
+				IPV6Address: "2001:db8::2",
+				IPV4Address: "192.0.2.2",
+				MACAddress:  "00:11:22:33:44:66"},
+			{
+				Name:       "ethNoIp",
+				MACAddress: "00:11:22:33:44:77"},
 		},
 		map[string]introspection.BaseInterfaceType{
 			"eth0": {
@@ -179,8 +187,9 @@ func TestGetNICDetails(t *testing.T) {
 			},
 		})
 
-	if len(nics) != 2 {
-		t.Errorf("Expected 2 NICs, got %d", len(nics))
+	// 5 expected because eth46 results in two items
+	if len(nics) != 5 {
+		t.Errorf("Expected 5 NICs, got %d", len(nics))
 	}
 	if (!reflect.DeepEqual(nics[0], metal3v1alpha1.NIC{
 		Name: "eth0",
@@ -199,6 +208,26 @@ func TestGetNICDetails(t *testing.T) {
 		MAC:       "66:77:88:99:aa:bb",
 		IP:        "2001:db8::1",
 		SpeedGbps: 1,
+	})) {
+		t.Errorf("Unexpected NIC data")
+	}
+	if (!reflect.DeepEqual(nics[2], metal3v1alpha1.NIC{
+		Name: "eth46",
+		MAC:  "00:11:22:33:44:66",
+		IP:   "192.0.2.2",
+	})) {
+		t.Errorf("Unexpected NIC data")
+	}
+	if (!reflect.DeepEqual(nics[3], metal3v1alpha1.NIC{
+		Name: "eth46",
+		MAC:  "00:11:22:33:44:66",
+		IP:   "2001:db8::2",
+	})) {
+		t.Errorf("Unexpected NIC data")
+	}
+	if (!reflect.DeepEqual(nics[4], metal3v1alpha1.NIC{
+		Name: "ethNoIp",
+		MAC:  "00:11:22:33:44:77",
 	})) {
 		t.Errorf("Unexpected NIC data")
 	}


### PR DESCRIPTION
This is a cherry-pick of https://github.com/metal3-io/baremetal-operator/pull/758

Currently we assume only an ipv4 or an ipv6 IP exists in the
inspection data, but it's valid for both to exist in a dual-stack
scenario.

To avoid changing the BMH API, in this case we create an additional
nic entry in the list, which will contain each IP but otherwise
the same data.