### PR TITLE
Bug 1917484: Don't adopt after clean failure during deprovisioning

### DIFF
--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -172,6 +172,23 @@ func TestDeprovision(t *testing.T) {
 			expectedRequestAfter: 10,
 			expectedDirty:        true,
 		},
+		{
+			name: "clean fail state",
+			ironic: testserver.NewIronic(t).WithDefaultResponses().Node(nodes.Node{
+				ProvisionState: string(nodes.CleanFail),
+				UUID:           nodeUUID,
+			}),
+			expectedRequestAfter: 10,
+			expectedDirty:        true,
+		},
+		{
+			name: "manageable state",
+			ironic: testserver.NewIronic(t).Ready().Node(nodes.Node{
+				ProvisionState: string(nodes.Manageable),
+				UUID:           nodeUUID,
+			}),
+			expectedDirty: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/provisioner/ironic/result.go
+++ b/pkg/provisioner/ironic/result.go
@@ -1,0 +1,40 @@
+package ironic
+
+import (
+	"time"
+
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+)
+
+func retryAfterDelay(delay time.Duration) (provisioner.Result, error) {
+	// TODO(zaneb): this is currently indistinguishable from the result of
+	// operationContinuing() from the caller's perspective. Changes are
+	// required to the Result structure to enable this to be distinguished.
+	return provisioner.Result{
+		Dirty:        true,
+		RequeueAfter: delay,
+	}, nil
+}
+
+func hostUpdated() (provisioner.Result, error) {
+	return provisioner.Result{Dirty: true}, nil
+}
+
+func operationContinuing(delay time.Duration) (provisioner.Result, error) {
+	return provisioner.Result{
+		Dirty:        true,
+		RequeueAfter: delay,
+	}, nil
+}
+
+func operationComplete() (provisioner.Result, error) {
+	return provisioner.Result{}, nil
+}
+
+func operationFailed(message string) (provisioner.Result, error) {
+	return provisioner.Result{ErrorMessage: message}, nil
+}
+
+func transientError(err error) (provisioner.Result, error) {
+	return provisioner.Result{}, err
+}


### PR DESCRIPTION
This is meant to supersede #121. It adds the commit `Ironic: Add result functions` without which it cannot be built. 