### PR TITLE
Generate BMH CRD with annotations needed for OpenShift

### DIFF
--- a/config/crd/ocp/ocp_kustomization.yaml
+++ b/config/crd/ocp/ocp_kustomization.yaml
@@ -1,0 +1,25 @@
+commonAnnotations:
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/metal3.io_baremetalhosts.yaml
+# +kubebuilder:scaffold:crdkustomizeresource
+
+patchesStrategicMerge:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+#- patches/webhook_in_baremetalhosts.yaml
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+#- patches/cainjection_in_baremetalhosts.yaml
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml


### PR DESCRIPTION
* Add a new kustomization file that adds the OpenShift annotations
* Only on the OpenShift platform, use this file to generate the BMH CRD
* Copy this generated CRD to the /manifests directory so that the CVO can install it 

This fix is being added so that the BMH CRD does not have to be manually kept in sync with the BMO CRD. 