### PR TITLE
Copy generated BMH CRD to /manifests directory for CVO to install it

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -4,8 +4,16 @@ COPY . .
 RUN make build
 RUN make tools
 
+RUN cp /go/src/github.com/metal3-io/baremetal-operator/config/crd/ocp/ocp_kustomization.yaml /go/src/github.com/metal3-io/baremetal-operator/config/crd/kustomization.yaml &&\
+    make manifests &&\
+    mkdir /go/src/github.com/metal3-io/baremetal-operator/manifests &&\
+    cp /go/src/github.com/metal3-io/baremetal-operator/config/render/capm3.yaml /go/src/github.com/metal3-io/baremetal-operator/manifests/0000_30_baremetal-operator_01_baremetalhost.crd.yaml
+
 FROM registry.ci.openshift.org/ocp/4.8:base
 COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/bin/baremetal-operator /
 COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/bin/get-hardware-details /
 COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/bin/make-bm-worker /
 COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/bin/make-virt-host /
+COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/manifests /manifests
+
+LABEL io.openshift.release.operator=true


### PR DESCRIPTION
Use the OpenShift specific kustomization.yaml to generate the BMH CRD and copy that to the /manifests directory with a name that CVO understands. A run level of 30 ensures that this CRD is installed before CVO manifests are installed at run level 31.