### PR TITLE
Bug 1941636 - BM worker nodes deployment with virtual media failed while trying to clean raid

### DIFF
--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -450,7 +450,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -462,7 +462,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -474,7 +474,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -498,7 +498,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -510,7 +510,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -522,7 +522,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -534,7 +534,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 
@@ -618,7 +618,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			boot:       "ilo-ipxe",
 			management: "",
 			power:      "",
-			raid:       "",
+			raid:       "no-raid",
 			vendor:     "",
 		},
 

--- a/pkg/bmc/ibmc.go
+++ b/pkg/bmc/ibmc.go
@@ -91,7 +91,7 @@ func (a *ibmcAccessDetails) PowerInterface() string {
 }
 
 func (a *ibmcAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *ibmcAccessDetails) VendorInterface() string {

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -87,7 +87,7 @@ func (a *iDracAccessDetails) PowerInterface() string {
 }
 
 func (a *iDracAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *iDracAccessDetails) VendorInterface() string {

--- a/pkg/bmc/ilo4.go
+++ b/pkg/bmc/ilo4.go
@@ -83,7 +83,7 @@ func (a *iLOAccessDetails) PowerInterface() string {
 }
 
 func (a *iLOAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *iLOAccessDetails) VendorInterface() string {

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -86,7 +86,7 @@ func (a *ipmiAccessDetails) PowerInterface() string {
 }
 
 func (a *ipmiAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *ipmiAccessDetails) VendorInterface() string {

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -100,7 +100,7 @@ func (a *redfishAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *redfishAccessDetails) VendorInterface() string {

--- a/pkg/bmc/redfish_virtualmedia.go
+++ b/pkg/bmc/redfish_virtualmedia.go
@@ -79,7 +79,7 @@ func (a *redfishVirtualMediaAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishVirtualMediaAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *redfishVirtualMediaAccessDetails) VendorInterface() string {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1222,7 +1222,7 @@ func (p *ironicProvisioner) ironicHasSameImage(ironicNode *nodes.Node) (sameImag
 
 func (p *ironicProvisioner) buildManualCleaningSteps() (cleanSteps []nodes.CleanStep, err error) {
 	// Build raid clean steps
-	if p.bmcAccess.RAIDInterface() != "" {
+	if p.bmcAccess.RAIDInterface() != "no-raid" {
 		cleanSteps = append(cleanSteps, BuildRAIDCleanSteps(p.host.Status.Provisioning.RAID)...)
 	} else if p.host.Status.Provisioning.RAID != nil {
 		return nil, fmt.Errorf("RAID settings are defined, but the node's driver %s does not support RAID", p.bmcAccess.Driver())
@@ -1234,7 +1234,7 @@ func (p *ironicProvisioner) buildManualCleaningSteps() (cleanSteps []nodes.Clean
 }
 
 func (p *ironicProvisioner) startManualCleaning(ironicNode *nodes.Node) (success bool, result provisioner.Result, err error) {
-	if p.bmcAccess.RAIDInterface() != "" {
+	if p.bmcAccess.RAIDInterface() != "no-raid" {
 		// Set raid configuration
 		err = setTargetRAIDCfg(p, ironicNode)
 		if err != nil {

--- a/pkg/provisioner/ironic/testbmc/testbmc.go
+++ b/pkg/provisioner/ironic/testbmc/testbmc.go
@@ -75,7 +75,7 @@ func (a *testAccessDetails) PowerInterface() string {
 }
 
 func (a *testAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *testAccessDetails) VendorInterface() string {


### PR DESCRIPTION
Instead of using `""` we will be using `no-raid`.
The support for RAID was considering  RAIDInterface defaul value as `""`
to generate the clean steps, this is causing errors in vmedia
deployments with idrac because it uses `no-raid`:

"Node failed to start the first cleaning step. Error: node does not support
this clean step: {'interface': 'raid', 'step': 'delete_configuration'}"