### PR TITLE
WIP: baremetal: Add privLevel to bmc data

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -231,6 +231,10 @@ type BMCDetails struct {
 	// insecure because it allows a man-in-the-middle to intercept the
 	// connection.
 	DisableCertificateVerification bool `json:"disableCertificateVerification,omitempty"`
+
+	// privLevel is the ipmi privilage level to used when authenicating, it is ignore
+	// when not using ipmi
+	PrivLevel string `json:"privLevel,omitempty"`
 }
 
 // HardwareRAIDVolume defines the desired configuration of volume in hardware RAID

--- a/cmd/make-bm-worker/templates/templates.go
+++ b/cmd/make-bm-worker/templates/templates.go
@@ -43,6 +43,9 @@ spec:
 {{- if .DisableCertificateVerification }}
   disableCertificateVerification: true
 {{- end}}
+{{- if .PrivLevel }}
+  privLevel: .PrivLevel
+{{- end}}
 `
 
 // Template holds the arguments to pass to the template.

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -86,6 +86,14 @@ spec:
                   disableCertificateVerification:
                     description: DisableCertificateVerification disables verification of server certificates when using HTTPS to connect to the BMC. This is required when the server certificate is self-signed, but is insecure because it allows a man-in-the-middle to intercept the connection.
                     type: boolean
+                  privLevel:
+                    default: ADMINISTRATOR
+                    description: privLevel is the ipmi privilage level to use when authenicating, it is ignored when not using ipmi
+                    enum:
+                      - ADMINISTRATOR
+                      - OPERATOR
+                      - USER
+                    type: string
                 required:
                 - address
                 - credentialsName

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -84,6 +84,14 @@ spec:
                   disableCertificateVerification:
                     description: DisableCertificateVerification disables verification of server certificates when using HTTPS to connect to the BMC. This is required when the server certificate is self-signed, but is insecure because it allows a man-in-the-middle to intercept the connection.
                     type: boolean
+                  privLevel:
+                    default: ADMINISTRATOR
+                    description: privLevel is the ipmi privilage level to use when authenicating, it is ignored when not using ipmi
+                    enum:
+                      - ADMINISTRATOR
+                      - OPERATOR
+                      - USER
+                    type: string
                 required:
                 - address
                 - credentialsName

--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -11,7 +11,7 @@ import (
 
 // AccessDetailsFactory describes a callable that returns a new
 // AccessDetails based on the input parameters.
-type AccessDetailsFactory func(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error)
+type AccessDetailsFactory func(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error)
 
 var factories = map[string]AccessDetailsFactory{}
 
@@ -110,7 +110,7 @@ func getParsedURL(address string) (parsedURL *url.URL, err error) {
 
 // NewAccessDetails creates an AccessDetails structure from the URL
 // for a BMC.
-func NewAccessDetails(address string, disableCertificateVerification bool) (AccessDetails, error) {
+func NewAccessDetails(address string, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 
 	if address == "" {
 		return nil, errors.New("missing BMC address")
@@ -126,5 +126,5 @@ func NewAccessDetails(address string, disableCertificateVerification bool) (Acce
 		return nil, &UnknownBMCTypeError{address, parsedURL.Scheme}
 	}
 
-	return factory(parsedURL, disableCertificateVerification)
+	return factory(parsedURL, disableCertificateVerification, privLevel)
 }

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -647,7 +647,7 @@ func TestStaticDriverInfo(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			acc, err := NewAccessDetails(tc.input, false)
+			acc, err := NewAccessDetails(tc.input, false, "")
 			if err != nil {
 				t.Fatalf("unexpected parse error: %v", err)
 			}
@@ -1082,7 +1082,7 @@ func TestDriverInfo(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			acc, err := NewAccessDetails(tc.input, true)
+			acc, err := NewAccessDetails(tc.input, true, "")
 			if err != nil {
 				t.Fatalf("unexpected parse error: %v", err)
 			}
@@ -1104,7 +1104,7 @@ func TestDriverInfo(t *testing.T) {
 }
 
 func TestUnknownType(t *testing.T) {
-	acc, err := NewAccessDetails("foo://192.168.122.1", false)
+	acc, err := NewAccessDetails("foo://192.168.122.1", false, "")
 	if err == nil || acc != nil {
 		t.Fatalf("unexpected parse success")
 	}

--- a/pkg/bmc/ibmc.go
+++ b/pkg/bmc/ibmc.go
@@ -9,12 +9,13 @@ func init() {
 	RegisterFactory("ibmc", newIbmcAccessDetails, []string{"http", "https"})
 }
 
-func newIbmcAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newIbmcAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &ibmcAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		host:                           parsedURL.Host,
 		path:                           parsedURL.Path,
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -23,6 +24,7 @@ type ibmcAccessDetails struct {
 	host                           string
 	path                           string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *ibmcAccessDetails) Type() string {

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -9,13 +9,14 @@ func init() {
 	RegisterFactory("idrac", newIDRACAccessDetails, []string{"http", "https"})
 }
 
-func newIDRACAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newIDRACAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &iDracAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		path:                           parsedURL.Path,
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -25,6 +26,7 @@ type iDracAccessDetails struct {
 	hostname                       string
 	path                           string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *iDracAccessDetails) Type() string {

--- a/pkg/bmc/idrac_virtualmedia.go
+++ b/pkg/bmc/idrac_virtualmedia.go
@@ -9,12 +9,13 @@ func init() {
 	RegisterFactory("idrac-virtualmedia", newRedfishiDracVirtualMediaAccessDetails, schemes)
 }
 
-func newRedfishiDracVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newRedfishiDracVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &redfishiDracVirtualMediaAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		host:                           parsedURL.Host,
 		path:                           parsedURL.Path,
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -23,6 +24,7 @@ type redfishiDracVirtualMediaAccessDetails struct {
 	host                           string
 	path                           string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) Type() string {

--- a/pkg/bmc/ilo4.go
+++ b/pkg/bmc/ilo4.go
@@ -10,12 +10,13 @@ func init() {
 	RegisterFactory("ilo4", newILOAccessDetails, []string{"https"})
 }
 
-func newILOAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newILOAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &iLOAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -24,6 +25,7 @@ type iLOAccessDetails struct {
 	portNum                        string
 	hostname                       string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *iLOAccessDetails) Type() string {

--- a/pkg/bmc/ilo5.go
+++ b/pkg/bmc/ilo5.go
@@ -10,12 +10,13 @@ func init() {
 	RegisterFactory("ilo5", newILO5AccessDetails, []string{"https"})
 }
 
-func newILO5AccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newILO5AccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &iLO5AccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -24,6 +25,7 @@ type iLO5AccessDetails struct {
 	portNum                        string
 	hostname                       string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *iLO5AccessDetails) Type() string {

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -9,12 +9,13 @@ func init() {
 	RegisterFactory("libvirt", newIPMIAccessDetails, []string{})
 }
 
-func newIPMIAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newIPMIAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &ipmiAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -23,6 +24,7 @@ type ipmiAccessDetails struct {
 	portNum                        string
 	hostname                       string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 const ipmiDefaultPort = "623"
@@ -69,6 +71,9 @@ func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	}
 	if a.portNum == "" {
 		result["ipmi_port"] = ipmiDefaultPort
+	}
+	if len(a.privLevel) > 0 {
+		result["ipmi_priv_level"] = a.privLevel
 	}
 	return result
 }

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -8,12 +8,13 @@ func init() {
 	RegisterFactory("irmc", newIRMCAccessDetails, []string{})
 }
 
-func newIRMCAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newIRMCAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &iRMCAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -22,6 +23,7 @@ type iRMCAccessDetails struct {
 	portNum                        string
 	hostname                       string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *iRMCAccessDetails) Type() string {

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -12,22 +12,23 @@ func init() {
 	RegisterFactory("idrac-redfish", newRedfishiDracAccessDetails, schemes)
 }
 
-func redfishDetails(parsedURL *url.URL, disableCertificateVerification bool) *redfishAccessDetails {
+func redfishDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) *redfishAccessDetails {
 	return &redfishAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		host:                           parsedURL.Host,
 		path:                           parsedURL.Path,
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}
 }
 
-func newRedfishAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
-	return redfishDetails(parsedURL, disableCertificateVerification), nil
+func newRedfishAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
+	return redfishDetails(parsedURL, disableCertificateVerification, privLevel), nil
 }
 
-func newRedfishiDracAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newRedfishiDracAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &redfishiDracAccessDetails{
-		*redfishDetails(parsedURL, disableCertificateVerification),
+		*redfishDetails(parsedURL, disableCertificateVerification, privLevel),
 	}, nil
 }
 
@@ -36,6 +37,7 @@ type redfishAccessDetails struct {
 	host                           string
 	path                           string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 type redfishiDracAccessDetails struct {

--- a/pkg/bmc/redfish_virtualmedia.go
+++ b/pkg/bmc/redfish_virtualmedia.go
@@ -10,12 +10,13 @@ func init() {
 	RegisterFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
 }
 
-func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &redfishVirtualMediaAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		host:                           parsedURL.Host,
 		path:                           parsedURL.Path,
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -24,6 +25,7 @@ type redfishVirtualMediaAccessDetails struct {
 	host                           string
 	path                           string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *redfishVirtualMediaAccessDetails) Type() string {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -144,6 +144,8 @@ type ironicProvisioner struct {
 	bmcCreds bmc.Credentials
 	// the MAC address of the PXE boot interface
 	bootMACAddress string
+	// ipmi privlevel
+	privLevel string
 	// a client for talking to ironic
 	client *gophercloud.ServiceClient
 	// a client for talking to ironic-inspector
@@ -206,6 +208,7 @@ func newProvisionerWithIronicClients(hostData provisioner.HostData, publisher pr
 		bmcAddress:              hostData.BMCAddress,
 		disableCertVerification: hostData.DisableCertificateVerification,
 		bootMACAddress:          hostData.BootMACAddress,
+		privLevel:               hostData.PrivLevel,
 		client:                  clientIronic,
 		inspector:               clientInspector,
 		log:                     provisionerLogger,
@@ -242,7 +245,7 @@ func New(hostData provisioner.HostData, publisher provisioner.EventPublisher) (p
 }
 
 func (p *ironicProvisioner) bmcAccess() (bmc.AccessDetails, error) {
-	bmcAccess, err := bmc.NewAccessDetails(p.bmcAddress, p.disableCertVerification)
+	bmcAccess, err := bmc.NewAccessDetails(p.bmcAddress, p.disableCertVerification, p.privLevel)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse BMC address information")
 	}

--- a/pkg/provisioner/ironic/testbmc/testbmc.go
+++ b/pkg/provisioner/ironic/testbmc/testbmc.go
@@ -11,11 +11,12 @@ func init() {
 	bmc.RegisterFactory("test-needs-mac", newTestBMCAccessDetails, []string{})
 }
 
-func newTestBMCAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (bmc.AccessDetails, error) {
+func newTestBMCAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (bmc.AccessDetails, error) {
 	return &testAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		hostname:                       parsedURL.Hostname(),
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -23,6 +24,7 @@ type testAccessDetails struct {
 	bmcType                        string
 	hostname                       string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *testAccessDetails) Type() string {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -26,6 +26,7 @@ type HostData struct {
 	DisableCertificateVerification bool
 	BootMACAddress                 string
 	ProvisionerID                  string
+	PrivLevel                      string
 }
 
 func BuildHostData(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials) HostData {
@@ -34,6 +35,7 @@ func BuildHostData(host metal3v1alpha1.BareMetalHost, bmcCreds bmc.Credentials) 
 		BMCAddress:                     host.Spec.BMC.Address,
 		BMCCredentials:                 bmcCreds,
 		DisableCertificateVerification: host.Spec.BMC.DisableCertificateVerification,
+		PrivLevel:                      host.Spec.BMC.PrivLevel,
 		BootMACAddress:                 host.Spec.BootMACAddress,
 		ProvisionerID:                  host.Status.Provisioning.ID,
 	}


### PR DESCRIPTION
Add a new parameter to optionaly set the ipmi privilage
level used when connected to BMC's over ipmi, the default
"ADMINISTRATOR" isn't always available (e.g. in ibmcloud).