### PR TITLE
Bug 1949898: modify power_interface for irmc

### DIFF
--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -74,7 +74,7 @@ func (a *iRMCAccessDetails) ManagementInterface() string {
 }
 
 func (a *iRMCAccessDetails) PowerInterface() string {
-	return ""
+	return "ipmitool"
 }
 
 func (a *iRMCAccessDetails) RAIDInterface() string {


### PR DESCRIPTION
Modify the value of power_interface so that soft power off can be used directly.

When irmc power interface is used, Soft Reboot (Graceful Reset) and Soft Power Off (Graceful Power Off)
are only available if ServerView agents are installed.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>
(cherry picked from commit fa38361162644c43fcab7016b69d84aaa4dac9fe)