### PR TITLE
Bug 1960554: config: use rbacv1 instead of rbacv1beta1

### DIFF
--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -928,7 +928,7 @@ rules:
   verbs:
   - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: baremetal-operator-metrics-reader


### PR DESCRIPTION
This would allow CVO to drop rbacv1beta1 handling code