### PR TITLE
Bug 1969487: Avoid always do delete_configuration clean step

### DIFF
--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -151,11 +151,8 @@ func BuildRAIDCleanSteps(raid *metal3v1alpha1.RAIDConfig) (cleanSteps []nodes.Cl
 			Step:      "delete_configuration",
 		},
 	)
-	// If raid configuration is empty, only need to clear old configuration
-	if len(raid.HardwareRAIDVolumes) == 0 && len(raid.SoftwareRAIDVolumes) == 0 {
-		return
-	}
-	if len(raid.HardwareRAIDVolumes) == 0 && len(raid.SoftwareRAIDVolumes) != 0 {
+
+	if raid.HardwareRAIDVolumes == nil && raid.SoftwareRAIDVolumes != nil {
 		cleanSteps = append(
 			cleanSteps,
 			nodes.CleanStep{
@@ -164,6 +161,12 @@ func BuildRAIDCleanSteps(raid *metal3v1alpha1.RAIDConfig) (cleanSteps []nodes.Cl
 			},
 		)
 	}
+
+	// If raid configuration is empty, only need to clear old configuration
+	if len(raid.HardwareRAIDVolumes) == 0 && len(raid.SoftwareRAIDVolumes) == 0 {
+		return
+	}
+
 	// ‘create_configuration’ doesn’t remove existing disks. It is recommended
 	// that only the desired logical disks exist in the system after manual cleaning.
 	cleanSteps = append(

--- a/pkg/provisioner/ironic/raid.go
+++ b/pkg/provisioner/ironic/raid.go
@@ -139,6 +139,9 @@ func buildTargetSoftwareRAIDCfg(volumes []metal3v1alpha1.SoftwareRAIDVolume) (lo
 
 // BuildRAIDCleanSteps build the clean steps for RAID configuration from BaremetalHost spec
 func BuildRAIDCleanSteps(raid *metal3v1alpha1.RAIDConfig) (cleanSteps []nodes.CleanStep) {
+	if raid == nil {
+		return
+	}
 	// Add ‘delete_configuration’ before ‘create_configuration’ to make sure
 	// that only the desired logical disks exist in the system after manual cleaning.
 	cleanSteps = append(
@@ -148,8 +151,8 @@ func BuildRAIDCleanSteps(raid *metal3v1alpha1.RAIDConfig) (cleanSteps []nodes.Cl
 			Step:      "delete_configuration",
 		},
 	)
-	// If not configure raid, only need to clear old configuration
-	if raid == nil || (len(raid.HardwareRAIDVolumes) == 0 && len(raid.SoftwareRAIDVolumes) == 0) {
+	// If raid configuration is empty, only need to clear old configuration
+	if len(raid.HardwareRAIDVolumes) == 0 && len(raid.SoftwareRAIDVolumes) == 0 {
 		return
 	}
 	if len(raid.HardwareRAIDVolumes) == 0 && len(raid.SoftwareRAIDVolumes) != 0 {

--- a/pkg/provisioner/ironic/raid_test.go
+++ b/pkg/provisioner/ironic/raid_test.go
@@ -261,7 +261,7 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "volumes is nil",
+			name: "remove hardware RAID",
 			raid: &metal3v1alpha1.RAIDConfig{
 				HardwareRAIDVolumes: nil,
 				SoftwareRAIDVolumes: nil,
@@ -274,7 +274,7 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 			},
 		},
 		{
-			name: "volumes is empty",
+			name: "remove hardware RAID",
 			raid: &metal3v1alpha1.RAIDConfig{
 				HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{},
 				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
@@ -283,6 +283,23 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 				{
 					Interface: "raid",
 					Step:      "delete_configuration",
+				},
+			},
+		},
+		{
+			name: "remove software RAID",
+			raid: &metal3v1alpha1.RAIDConfig{
+				HardwareRAIDVolumes: nil,
+				SoftwareRAIDVolumes: []metal3v1alpha1.SoftwareRAIDVolume{},
+			},
+			expected: []nodes.CleanStep{
+				{
+					Interface: "raid",
+					Step:      "delete_configuration",
+				},
+				{
+					Interface: "deploy",
+					Step:      "erase_devices_metadata",
 				},
 			},
 		},

--- a/pkg/provisioner/ironic/raid_test.go
+++ b/pkg/provisioner/ironic/raid_test.go
@@ -256,14 +256,9 @@ func TestBuildRAIDCleanSteps(t *testing.T) {
 			},
 		},
 		{
-			name: "raid is nil",
-			raid: nil,
-			expected: []nodes.CleanStep{
-				{
-					Interface: "raid",
-					Step:      "delete_configuration",
-				},
-			},
+			name:     "raid is nil",
+			raid:     nil,
+			expected: nil,
 		},
 		{
 			name: "volumes is nil",


### PR DESCRIPTION
This is a downstream version of https://github.com/metal3-io/baremetal-operator/pull/908. Original message:

Signed-off-by: Zou Yu zouy.fnst@cn.fujitsu.com

When I test on a server(irmc) without a RAID controller, this will cause an error.
I am very sorry for ignored this situation in the previous code.