### PR TITLE
Bug 1969487: Disable raid feature for iRMC server

### DIFF
--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -81,7 +81,7 @@ func (a *iRMCAccessDetails) PowerInterface() string {
 }
 
 func (a *iRMCAccessDetails) RAIDInterface() string {
-	return "irmc"
+	return "no-raid"
 }
 
 func (a *iRMCAccessDetails) VendorInterface() string {

--- a/pkg/provisioner/ironic/prepare_test.go
+++ b/pkg/provisioner/ironic/prepare_test.go
@@ -124,7 +124,7 @@ func TestPrepare(t *testing.T) {
 			host.Status.Provisioning.ID = nodeUUID
 			prepData := provisioner.PrepareData{}
 			if tc.existRaidConfig {
-				host.Spec.BMC.Address = "irmc://test.bmc/"
+				host.Spec.BMC.Address = "idrac://test.bmc/"
 				prepData.RAIDConfig = &metal3v1alpha1.RAIDConfig{
 					HardwareRAIDVolumes: []metal3v1alpha1.HardwareRAIDVolume{
 						{


### PR DESCRIPTION
This is a downstream version of https://github.com/metal3-io/baremetal-operator/pull/911


Signed-off-by: Zou Yu zouy.fnst@cn.fujitsu.com

In view of the need for further discussion on [#908,](https://github.com/metal3-io/baremetal-operator/pull/908) we can first disable RAID settings for iRMC to avoid clean fail on iRMC servers that do not support hardware RAID.