### PR TITLE
Bug 1969487: Disable RAID for all drivers

### DIFF
--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -87,7 +87,9 @@ func (a *iDracAccessDetails) PowerInterface() string {
 }
 
 func (a *iDracAccessDetails) RAIDInterface() string {
-	return "idrac-wsman"
+	// Disabled RAID in OpenShift because we are not ready to support it
+	//return "idrac-wsman"
+	return "no-raid"
 }
 
 func (a *iDracAccessDetails) VendorInterface() string {

--- a/pkg/bmc/ilo5.go
+++ b/pkg/bmc/ilo5.go
@@ -83,7 +83,9 @@ func (a *iLO5AccessDetails) PowerInterface() string {
 }
 
 func (a *iLO5AccessDetails) RAIDInterface() string {
-	return "ilo5"
+	// Disabled RAID in OpenShift because we are not ready to support it
+	//return "ilo5"
+	return "no-raid"
 }
 
 func (a *iLO5AccessDetails) VendorInterface() string {


### PR DESCRIPTION
RAID support was disabled for the iRMC driver in #152, but per [discussion](https://github.com/openshift/baremetal-operator/pull/150/#issuecomment-858193623) we're not feeling confident about supporting RAID at all in 4.8, and there's every reason to think the known bug could affect other drivers. Therefore, disable RAID for everything until we're confident enough to want to support it.