### PR TITLE
Point ironic-inspector to the ironic image in quay

### DIFF
--- a/ironic-deployment/ironic/ironic.yaml
+++ b/ironic-deployment/ironic/ironic.yaml
@@ -85,13 +85,13 @@ spec:
             - mountPath: /shared
               name: ironic-data-volume
         - name: ironic-inspector
-          image: quay.io/metal3-io/ironic-inspector
+          image: quay.io/metal3-io/ironic
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: ironic-bmo-configmap
         - name: ironic-inspector-log-watch
-          image: quay.io/metal3-io/ironic-inspector
+          image: quay.io/metal3-io/ironic
           imagePullPolicy: Always
           command:
             - /bin/runlogwatch.sh

--- a/ironic-deployment/tls/default/tls.yaml
+++ b/ironic-deployment/tls/default/tls.yaml
@@ -51,7 +51,7 @@ spec:
           mountPath: "/certs/ca/mariadb"
           readOnly: true
       - name: httpd-reverse-proxy
-        image: quay.io/metal3-io/ironic-inspector
+        image: quay.io/metal3-io/ironic
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/ironic-deployment/tls/keepalived/tls.yaml
+++ b/ironic-deployment/tls/keepalived/tls.yaml
@@ -51,7 +51,7 @@ spec:
           mountPath: "/certs/ca/mariadb"
           readOnly: true
       - name: httpd-reverse-proxy
-        image: quay.io/metal3-io/ironic-inspector
+        image: quay.io/metal3-io/ironic
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -5,7 +5,7 @@ set -ex
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
-IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector"}
+IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic"}
 IRONIC_KEEPALIVED_IMAGE=${IRONIC_KEEPALIVED_IMAGE:-"quay.io/metal3-io/keepalived"}
 IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
 IRONIC_DATA_DIR=${IRONIC_DATA_DIR:-"/opt/metal3-dev-env/ironic"}


### PR DESCRIPTION
After ironic-inspector merges with ironic image, we need to change the
reference of the ironic-inspector container to point to the ironic image
in quay.

This should happen after https://github.com/metal3-io/ironic-image/pull/253

No hard dependency on https://github.com/openshift/ironic-image/pull/179

(cherry picked from commit 99fc4aeb7bae3c11bd3a638c3cc27334a6992f55)