### PR TITLE
Bug 1972374: Don't deprovision provisioned host due to error

### DIFF
--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -423,9 +423,6 @@ func (hsm *hostStateMachine) handleReady(info *reconcileInfo) actionResult {
 }
 
 func (hsm *hostStateMachine) provisioningCancelled() bool {
-	if hsm.Host.Status.ErrorMessage != "" {
-		return true
-	}
 	if hsm.Host.Spec.Image == nil {
 		return true
 	}
@@ -442,7 +439,7 @@ func (hsm *hostStateMachine) provisioningCancelled() bool {
 }
 
 func (hsm *hostStateMachine) handleProvisioning(info *reconcileInfo) actionResult {
-	if hsm.provisioningCancelled() {
+	if hsm.Host.Status.ErrorType != "" || hsm.provisioningCancelled() {
 		hsm.NextState = metal3v1alpha1.StateDeprovisioning
 		return actionComplete{}
 	}

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -526,6 +526,33 @@ func TestProvisioningCancelled(t *testing.T) {
 		},
 
 		{
+			Scenario: "provisioned with error",
+			Host: metal3v1alpha1.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost",
+					Namespace: "myns",
+				},
+				Spec: metal3v1alpha1.BareMetalHostSpec{
+					Image: &metal3v1alpha1.Image{
+						URL: "same",
+					},
+					Online: true,
+				},
+				Status: metal3v1alpha1.BareMetalHostStatus{
+					ErrorType:    metal3v1alpha1.ProvisionedRegistrationError,
+					ErrorMessage: "Adoption failed",
+					ErrorCount:   1,
+					Provisioning: metal3v1alpha1.ProvisionStatus{
+						Image: metal3v1alpha1.Image{
+							URL: "same",
+						},
+					},
+				},
+			},
+			Expected: false,
+		},
+
+		{
 			Scenario: "removed image",
 			Host: metal3v1alpha1.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
During provisioning, we want an error to cause the Host to be
deprovisioned again, but we very much do not want that to happen when
the Host is already provisioned. Due to an error in
0a7713bd3b4ff30aef2dac17c2d62a79bfe02872, provisioned Hosts were being
automatically deprovisioned whenever an error (other than a registration
error) occurred.

In practice this only manifested on Adopt() failures, since we don't yet
report power management failures.

(cherry picked from metal3-io#916)