### PR TITLE
Simplify build in Dockerfile.ocp

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
 WORKDIR /go/src/github.com/metal3-io/baremetal-operator
 COPY . .
-RUN make build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/baremetal-operator main.go
 RUN make tools
 
 RUN cp /go/src/github.com/metal3-io/baremetal-operator/config/crd/ocp/ocp_kustomization.yaml /go/src/github.com/metal3-io/baremetal-operator/config/crd/kustomization.yaml &&\


### PR DESCRIPTION
We build the baremetal-operator binary directly instead of using the
full Makefile target.  This should speed up the build by not
regenerating manifests, and by not building linting tools needlessly.

This also the way it's done upstream.