### PR TITLE
Bug 1928816: Explicitly set node bios_interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/go-logr/logr v0.4.0
 	github.com/golangci/golangci-lint v1.32.0
-	github.com/gophercloud/gophercloud v0.16.0
+	github.com/gophercloud/gophercloud v0.18.0
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/metal3-io/baremetal-operator/apis v0.0.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gookit/color v1.2.5/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gophercloud/gophercloud v0.16.0 h1:sWjPfypuzxRxjVbk3/MsU4H8jS0NNlyauZtIUl78BPU=
-github.com/gophercloud/gophercloud v0.16.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
+github.com/gophercloud/gophercloud v0.18.0 h1:V6hcuMPmjXg+js9flU8T3RIHDCjV7F5CG5GD0MRhP/w=
+github.com/gophercloud/gophercloud v0.18.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -54,6 +54,8 @@ type AccessDetails interface {
 	// (such as the kernel and ramdisk locations).
 	DriverInfo(bmcCreds Credentials) map[string]interface{}
 
+	BIOSInterface() string
+
 	// Boot interface to set
 	BootInterface() string
 

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -439,6 +439,7 @@ func TestStaticDriverInfo(t *testing.T) {
 		input      string
 		needsMac   bool
 		driver     string
+		bios       string
 		boot       string
 		management string
 		power      string
@@ -450,6 +451,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "ipmi://192.168.122.1:6233",
 			needsMac:   false,
 			driver:     "ipmi",
+			bios:       "",
 			boot:       "ipxe",
 			management: "",
 			power:      "",
@@ -462,6 +464,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "libvirt://192.168.122.1",
 			needsMac:   true,
 			driver:     "ipmi",
+			bios:       "",
 			boot:       "ipxe",
 			management: "",
 			power:      "",
@@ -474,6 +477,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac://192.168.122.1",
 			needsMac:   false,
 			driver:     "idrac",
+			bios:       "",
 			boot:       "ipxe",
 			management: "",
 			power:      "",
@@ -486,6 +490,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "irmc://192.168.122.1",
 			needsMac:   false,
 			driver:     "irmc",
+			bios:       "",
 			boot:       "pxe",
 			management: "",
 			power:      "",
@@ -498,6 +503,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "redfish://192.168.122.1",
 			needsMac:   true,
 			driver:     "redfish",
+			bios:       "",
 			boot:       "ipxe",
 			management: "",
 			power:      "",
@@ -510,6 +516,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "redfish-virtualmedia://192.168.122.1",
 			needsMac:   true,
 			driver:     "redfish",
+			bios:       "",
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
@@ -522,6 +529,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "redfish-virtualmedia+http://192.168.122.1",
 			needsMac:   true,
 			driver:     "redfish",
+			bios:       "",
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
@@ -534,6 +542,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "redfish-virtualmedia+https://192.168.122.1",
 			needsMac:   true,
 			driver:     "redfish",
+			bios:       "",
 			boot:       "redfish-virtual-media",
 			management: "",
 			power:      "",
@@ -546,6 +555,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac-redfish://192.168.122.1",
 			needsMac:   true,
 			driver:     "idrac",
+			bios:       "idrac-redfish",
 			boot:       "ipxe",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -558,6 +568,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:    "ilo5-virtualmedia://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
+			bios:     "",
 			boot:     "redfish-virtual-media",
 		},
 
@@ -566,6 +577,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:    "ilo5-virtualmedia+http://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
+			bios:     "",
 			boot:     "redfish-virtual-media",
 		},
 
@@ -574,6 +586,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:    "ilo5-virtualmedia+https://192.168.122.1",
 			needsMac: true,
 			driver:   "redfish",
+			bios:     "",
 			boot:     "redfish-virtual-media",
 		},
 
@@ -582,6 +595,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac-virtualmedia://192.168.122.1",
 			needsMac:   true,
 			driver:     "idrac",
+			bios:       "idrac-redfish",
 			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -594,6 +608,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac-virtualmedia+http://192.168.122.1",
 			needsMac:   true,
 			driver:     "idrac",
+			bios:       "idrac-redfish",
 			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -606,6 +621,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "idrac-virtualmedia+https://192.168.122.1",
 			needsMac:   true,
 			driver:     "idrac",
+			bios:       "idrac-redfish",
 			boot:       "idrac-redfish-virtual-media",
 			management: "idrac-redfish",
 			power:      "idrac-redfish",
@@ -618,6 +634,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "ibmc://192.168.122.1:6233",
 			needsMac:   true,
 			driver:     "ibmc",
+			bios:       "",
 			boot:       "pxe",
 			management: "ibmc",
 			power:      "ibmc",
@@ -630,6 +647,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "ilo4://192.168.122.1",
 			needsMac:   true,
 			driver:     "ilo",
+			bios:       "",
 			boot:       "ilo-ipxe",
 			management: "",
 			power:      "",
@@ -642,6 +660,7 @@ func TestStaticDriverInfo(t *testing.T) {
 			input:      "ilo5://192.168.122.1",
 			needsMac:   true,
 			driver:     "ilo5",
+			bios:       "",
 			boot:       "ilo-ipxe",
 			management: "",
 			power:      "",
@@ -663,6 +682,10 @@ func TestStaticDriverInfo(t *testing.T) {
 			if acc.BootInterface() != tc.boot {
 				t.Fatalf("Unexpected boot interface %q, expected %q",
 					acc.BootInterface(), tc.boot)
+			}
+			if acc.BIOSInterface() != tc.bios {
+				t.Fatalf("Unexpected bios interface %q, expected %q",
+					acc.BIOSInterface(), tc.bios)
 			}
 		})
 	}

--- a/pkg/bmc/ibmc.go
+++ b/pkg/bmc/ibmc.go
@@ -81,6 +81,10 @@ func (a *ibmcAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	return result
 }
 
+func (a *ibmcAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *ibmcAccessDetails) BootInterface() string {
 	return "pxe"
 }

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -76,6 +76,10 @@ func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfa
 	return result
 }
 
+func (a *iDracAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *iDracAccessDetails) BootInterface() string {
 	return "ipxe"
 }

--- a/pkg/bmc/idrac_virtualmedia.go
+++ b/pkg/bmc/idrac_virtualmedia.go
@@ -70,6 +70,10 @@ func (a *redfishiDracVirtualMediaAccessDetails) Driver() string {
 	return "idrac"
 }
 
+func (a *redfishiDracVirtualMediaAccessDetails) BIOSInterface() string {
+	return "idrac-redfish"
+}
+
 func (a *redfishiDracVirtualMediaAccessDetails) BootInterface() string {
 	return "idrac-redfish-virtual-media"
 }

--- a/pkg/bmc/ilo4.go
+++ b/pkg/bmc/ilo4.go
@@ -72,6 +72,10 @@ func (a *iLOAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface
 	return result
 }
 
+func (a *iLOAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *iLOAccessDetails) BootInterface() string {
 	return "ilo-ipxe"
 }

--- a/pkg/bmc/ilo5.go
+++ b/pkg/bmc/ilo5.go
@@ -72,6 +72,10 @@ func (a *iLO5AccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	return result
 }
 
+func (a *iLO5AccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *iLO5AccessDetails) BootInterface() string {
 	return "ilo-ipxe"
 }

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -91,6 +91,10 @@ func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	return result
 }
 
+func (a *ipmiAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *ipmiAccessDetails) BootInterface() string {
 	return "ipxe"
 }

--- a/pkg/bmc/irmc.go
+++ b/pkg/bmc/irmc.go
@@ -70,6 +70,10 @@ func (a *iRMCAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	return result
 }
 
+func (a *iRMCAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *iRMCAccessDetails) BootInterface() string {
 	return "pxe"
 }

--- a/pkg/bmc/redfish.go
+++ b/pkg/bmc/redfish.go
@@ -100,6 +100,10 @@ func (a *redfishAccessDetails) DriverInfo(bmcCreds Credentials) map[string]inter
 	return result
 }
 
+func (a *redfishAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 // That can be either pxe or redfish-virtual-media
 func (a *redfishAccessDetails) BootInterface() string {
 	return "ipxe"
@@ -133,9 +137,12 @@ func (a *redfishAccessDetails) BuildBIOSSettings(firmwareConfig *metal3v1alpha1.
 }
 
 // iDrac Redfish Overrides
-
 func (a *redfishiDracAccessDetails) Driver() string {
 	return "idrac"
+}
+
+func (a *redfishiDracAccessDetails) BIOSInterface() string {
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracAccessDetails) BootInterface() string {

--- a/pkg/bmc/redfish_virtualmedia.go
+++ b/pkg/bmc/redfish_virtualmedia.go
@@ -69,6 +69,10 @@ func (a *redfishVirtualMediaAccessDetails) DriverInfo(bmcCreds Credentials) map[
 	return result
 }
 
+func (a *redfishVirtualMediaAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *redfishVirtualMediaAccessDetails) BootInterface() string {
 	return "redfish-virtual-media"
 }

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -367,6 +367,7 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 			p.client,
 			nodes.CreateOpts{
 				Driver:              bmcAccess.Driver(),
+				BIOSInterface:       bmcAccess.BIOSInterface(),
 				BootInterface:       bmcAccess.BootInterface(),
 				Name:                p.objectMeta.Name,
 				DriverInfo:          driverInfo,

--- a/pkg/provisioner/ironic/prepare_test.go
+++ b/pkg/provisioner/ironic/prepare_test.go
@@ -23,6 +23,7 @@ func (r *RAIDTestBMC) NeedsMAC() bool                                        { r
 func (r *RAIDTestBMC) Driver() string                                        { return "raid-test" }
 func (r *RAIDTestBMC) DisableCertificateVerification() bool                  { return false }
 func (r *RAIDTestBMC) DriverInfo(bmc.Credentials) (i map[string]interface{}) { return }
+func (r *RAIDTestBMC) BIOSInterface() string                                 { return "" }
 func (r *RAIDTestBMC) BootInterface() string                                 { return "" }
 func (r *RAIDTestBMC) ManagementInterface() string                           { return "" }
 func (r *RAIDTestBMC) PowerInterface() string                                { return "" }

--- a/pkg/provisioner/ironic/testbmc/testbmc.go
+++ b/pkg/provisioner/ironic/testbmc/testbmc.go
@@ -63,6 +63,10 @@ func (a *testAccessDetails) DriverInfo(bmcCreds bmc.Credentials) map[string]inte
 	return result
 }
 
+func (a *testAccessDetails) BIOSInterface() string {
+	return ""
+}
+
 func (a *testAccessDetails) BootInterface() string {
 	return "ipxe"
 }

--- a/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
+++ b/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
@@ -13,7 +13,7 @@
       Run gophercloud acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test/run.yaml
     timeout: 18000 # 5 hours
-    nodeset: ubuntu-bionic
+    nodeset: ubuntu-focal
 
 - job:
     name: gophercloud-acceptance-test-ironic
@@ -21,7 +21,7 @@
     description: |
       Run gophercloud ironic acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test-ironic/run.yaml
-    nodeset: ubuntu-bionic
+    nodeset: ubuntu-focal
 
 - job:
     name: gophercloud-acceptance-test-ussuri

--- a/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
@@ -1,4 +1,67 @@
-## 0.17.0 (Unreleased)
+## 0.19.0 (Unreleased)
+
+## 0.18.0 (June 11, 2021)
+
+NOTES / BREAKING CHANGES
+
+* As of [GH-2160](https://github.com/gophercloud/gophercloud/pull/2160), Gophercloud no longer URL encodes Object Storage containers and object names. You can still encode them yourself before passing the names to the Object Storage functions.
+
+* `baremetal/v1/nodes.ListBIOSSettings` now takes three parameters. The third, new, parameter is `ListBIOSSettingsOptsBuilder` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+
+BUG FIXES
+
+* Fixed expected OK codes to use default codes [GH-2173](https://github.com/gophercloud/gophercloud/pull/2173)
+* Fixed inablity to create sub-containers (objects with `/` in their name) [GH-2160](https://github.com/gophercloud/gophercloud/pull/2160)
+
+IMPROVEMENTS
+
+* Added `orchestration/v1/stacks.ListOpts.ShowHidden` [GH-2104](https://github.com/gophercloud/gophercloud/pull/2104)
+* Added `loadbalancer/v2/listeners.ProtocolSCTP` [GH-2149](https://github.com/gophercloud/gophercloud/pull/2149)
+* Added `loadbalancer/v2/listeners.CreateOpts.TLSVersions` [GH-2150](https://github.com/gophercloud/gophercloud/pull/2150)
+* Added `loadbalancer/v2/listeners.UpdateOpts.TLSVersions` [GH-2150](https://github.com/gophercloud/gophercloud/pull/2150)
+* Added `baremetal/v1/nodes.CreateOpts.NetworkData` [GH-2154](https://github.com/gophercloud/gophercloud/pull/2154)
+* Added `baremetal/v1/nodes.Node.NetworkData` [GH-2154](https://github.com/gophercloud/gophercloud/pull/2154)
+* Added `loadbalancer/v2/pools.ProtocolPROXYV2` [GH-2158](https://github.com/gophercloud/gophercloud/pull/2158)
+* Added `loadbalancer/v2/pools.ProtocolSCTP` [GH-2158](https://github.com/gophercloud/gophercloud/pull/2158)
+* Added `placement/v1/resourceproviders.GetAllocations` [GH-2162](https://github.com/gophercloud/gophercloud/pull/2162)
+* Added `baremetal/v1/nodes.CreateOpts.BIOSInterface` [GH-2164](https://github.com/gophercloud/gophercloud/pull/2164)
+* Added `baremetal/v1/nodes.Node.BIOSInterface` [GH-2164](https://github.com/gophercloud/gophercloud/pull/2164)
+* Added `baremetal/v1/nodes.NodeValidation.BIOS` [GH-2164](https://github.com/gophercloud/gophercloud/pull/2164)
+* Added `baremetal/v1/nodes.ListBIOSSettings` [GH-2171](https://github.com/gophercloud/gophercloud/pull/2171)
+* Added `baremetal/v1/nodes.GetBIOSSetting` [GH-2171](https://github.com/gophercloud/gophercloud/pull/2171)
+* Added `baremetal/v1/nodes.ListBIOSSettingsOpts` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.AttributeType` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.AllowableValues` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.LowerBound` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.UpperBound` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.MinLength` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.MaxLength` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.ReadOnly` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.ResetRequired` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.Unique` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+
+## 0.17.0 (April 9, 2021)
+
+IMPROVEMENTS
+
+* `networking/v2/extensions/quotas.QuotaDetail.Reserved` can handle both `int` and `string` values [GH-2126](https://github.com/gophercloud/gophercloud/pull/2126)
+* Added `blockstorage/v3/volumetypes.ListExtraSpecs` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+* Added `blockstorage/v3/volumetypes.GetExtraSpec` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+* Added `blockstorage/v3/volumetypes.CreateExtraSpecs` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+* Added `blockstorage/v3/volumetypes.UpdateExtraSpec` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+* Added `blockstorage/v3/volumetypes.DeleteExtraSpec` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+* Added `identity/v3/roles.ListAssignmentOpts.IncludeNames` [GH-2133](https://github.com/gophercloud/gophercloud/pull/2133)
+* Added `identity/v3/roles.AssignedRoles.Name` [GH-2133](https://github.com/gophercloud/gophercloud/pull/2133)
+* Added `identity/v3/roles.Domain.Name` [GH-2133](https://github.com/gophercloud/gophercloud/pull/2133)
+* Added `identity/v3/roles.Project.Name` [GH-2133](https://github.com/gophercloud/gophercloud/pull/2133)
+* Added `identity/v3/roles.User.Name` [GH-2133](https://github.com/gophercloud/gophercloud/pull/2133)
+* Added `identity/v3/roles.Group.Name` [GH-2133](https://github.com/gophercloud/gophercloud/pull/2133)
+* Added `blockstorage/extensions/availabilityzones.List` [GH-2135](https://github.com/gophercloud/gophercloud/pull/2135)
+* Added `blockstorage/v3/volumetypes.ListAccesses` [GH-2138](https://github.com/gophercloud/gophercloud/pull/2138)
+* Added `blockstorage/v3/volumetypes.AddAccess` [GH-2138](https://github.com/gophercloud/gophercloud/pull/2138)
+* Added `blockstorage/v3/volumetypes.RemoveAccess` [GH-2138](https://github.com/gophercloud/gophercloud/pull/2138)
+* Added `blockstorage/v3/qos.Create` [GH-2140](https://github.com/gophercloud/gophercloud/pull/2140)
+* Added `blockstorage/v3/qos.Delete` [GH-2140](https://github.com/gophercloud/gophercloud/pull/2140)
 
 ## 0.16.0 (February 23, 2021)
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/requests.go
@@ -185,6 +185,9 @@ type CreateOpts struct {
 	// Requires microversion 1.47 or later.
 	AutomatedClean *bool `json:"automated_clean,omitempty"`
 
+	// The BIOS interface for a Node, e.g. “redfish”.
+	BIOSInterface string `json:"bios_interface,omitempty"`
+
 	// The boot interface for a Node, e.g. “pxe”.
 	BootInterface string `json:"boot_interface,omitempty"`
 
@@ -247,6 +250,9 @@ type CreateOpts struct {
 
 	// A string or UUID of the tenant who owns the baremetal node.
 	Owner string `json:"owner,omitempty"`
+
+	// Static network configuration to use during deployment and cleaning.
+	NetworkData map[string]interface{} `json:"network_data,omitempty"`
 }
 
 // ToNodeCreateMap assembles a request body based on the contents of a CreateOpts.
@@ -629,6 +635,61 @@ func SetRAIDConfig(client *gophercloud.ServiceClient, id string, raidConfigOptsB
 
 	resp, err := client.Put(raidConfigURL(client, id), reqBody, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListBIOSSettingsOptsBuilder allows extensions to add additional parameters to the
+// ListBIOSSettings request.
+type ListBIOSSettingsOptsBuilder interface {
+	ToListBIOSSettingsOptsQuery() (string, error)
+}
+
+// ListBIOSSettingsOpts defines query options that can be passed to ListBIOSettings
+type ListBIOSSettingsOpts struct {
+	// Provide additional information for the BIOS Settings
+	Detail bool `q:"detail"`
+
+	// One or more fields to be returned in the response.
+	Fields []string `q:"fields"`
+}
+
+// ToListBIOSSettingsOptsQuery formats a ListBIOSSettingsOpts into a query string
+func (opts ListBIOSSettingsOpts) ToListBIOSSettingsOptsQuery() (string, error) {
+	if opts.Detail == true && len(opts.Fields) > 0 {
+		return "", fmt.Errorf("cannot have both fields and detail options for BIOS settings")
+	}
+
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Get the current BIOS Settings for the given Node.
+// To use the opts requires microversion 1.74.
+func ListBIOSSettings(client *gophercloud.ServiceClient, id string, opts ListBIOSSettingsOptsBuilder) (r ListBIOSSettingsResult) {
+	url := biosListSettingsURL(client, id)
+	if opts != nil {
+
+		query, err := opts.ToListBIOSSettingsOptsQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+
+	resp, err := client.Get(url, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get one BIOS Setting for the given Node.
+func GetBIOSSetting(client *gophercloud.ServiceClient, id string, setting string) (r GetBIOSSettingResult) {
+	resp, err := client.Get(biosGetSettingURL(client, id, setting), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/urls.go
@@ -57,3 +57,11 @@ func provisionStateURL(client *gophercloud.ServiceClient, id string) string {
 func raidConfigURL(client *gophercloud.ServiceClient, id string) string {
 	return statesResourceURL(client, id, "raid")
 }
+
+func biosListSettingsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "bios")
+}
+
+func biosGetSettingURL(client *gophercloud.ServiceClient, id string, setting string) string {
+	return client.ServiceURL("nodes", id, "bios", setting)
+}

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -440,7 +440,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 		respErr := ErrUnexpectedResponseCode{
 			URL:            url,
 			Method:         method,
-			Expected:       options.OkCodes,
+			Expected:       okc,
 			Actual:         resp.StatusCode,
 			Body:           body,
 			ResponseHeader: resp.Header,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/jsonschema
 github.com/googleapis/gnostic/openapiv2
-# github.com/gophercloud/gophercloud v0.16.0
+# github.com/gophercloud/gophercloud v0.18.0
 ## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack/baremetal/httpbasic


### PR DESCRIPTION
Ironic sets the bios_interface by default for all drivers. For some drivers - particularly idrac-virtualmedia, the default should be overridden. If not explicitly set, Ironic will use the default.

This requires an upgrade to a Gophercloud release that supports BIOSInterface.