### PR TITLE
Bug 1983190: Add LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE variable

### DIFF
--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -65,6 +65,7 @@ func (f *ironicProvisionerFactory) init() error {
 		"deployKernelURL", f.config.deployKernelURL,
 		"deployRamdiskURL", f.config.deployRamdiskURL,
 		"deployISOURL", f.config.deployISOURL,
+		"liveISOForcePersistentBootDevice", f.config.liveISOForcePersistentBootDevice,
 		"CACertFile", tlsConf.TrustedCAFile,
 		"ClientCertFile", tlsConf.ClientCertificateFile,
 		"ClientPrivKeyFile", tlsConf.ClientPrivateKeyFile,
@@ -136,6 +137,13 @@ func loadConfigFromEnv() (ironicConfig, error) {
 			return c, fmt.Errorf("Invalid value set for variable PROVISIONING_LIMIT=%s", maxHostsStr)
 		}
 		c.maxBusyHosts = value
+	}
+
+	if forcePersistentBootDevice := os.Getenv("LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE"); forcePersistentBootDevice != "" {
+		if forcePersistentBootDevice != "Default" && forcePersistentBootDevice != "Always" && forcePersistentBootDevice != "Never" {
+			return c, fmt.Errorf("Invalid value for variable LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE, must be one of Default, Always or Never")
+		}
+		c.liveISOForcePersistentBootDevice = forcePersistentBootDevice
 	}
 
 	return c, nil

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -61,10 +61,11 @@ func NewMacAddressConflictError(address, node string) error {
 }
 
 type ironicConfig struct {
-	deployKernelURL  string
-	deployRamdiskURL string
-	deployISOURL     string
-	maxBusyHosts     int
+	deployKernelURL                  string
+	deployRamdiskURL                 string
+	deployISOURL                     string
+	liveISOForcePersistentBootDevice string
+	maxBusyHosts                     int
 }
 
 // Provisioner implements the provisioning.Provisioner interface
@@ -699,6 +700,14 @@ func (p *ironicProvisioner) setLiveIsoUpdateOptsForNode(ironicNode *nodes.Node, 
 	updater.
 		SetInstanceInfoOpts(optValues, ironicNode).
 		SetTopLevelOpt("deploy_interface", "ramdisk", ironicNode.DeployInterface)
+
+	driverOptValues := optionsData{"force_persistent_boot_device": "Default"}
+	if p.config.liveISOForcePersistentBootDevice != "" {
+		driverOptValues = optionsData{
+			"force_persistent_boot_device": p.config.liveISOForcePersistentBootDevice,
+		}
+	}
+	updater.SetDriverInfoOpts(driverOptValues, ironicNode)
 }
 
 func (p *ironicProvisioner) setDirectDeployUpdateOptsForNode(ironicNode *nodes.Node, imageData *metal3v1alpha1.Image, updater *nodeUpdater) {
@@ -732,6 +741,11 @@ func (p *ironicProvisioner) setDirectDeployUpdateOptsForNode(ironicNode *nodes.N
 	updater.
 		SetInstanceInfoOpts(optValues, ironicNode).
 		SetTopLevelOpt("deploy_interface", "direct", ironicNode.DeployInterface)
+
+	driverOptValues := optionsData{
+		"force_persistent_boot_device": "Default",
+	}
+	updater.SetDriverInfoOpts(driverOptValues, ironicNode)
 }
 
 func (p *ironicProvisioner) setCustomDeployUpdateOptsForNode(ironicNode *nodes.Node, imageData *metal3v1alpha1.Image, updater *nodeUpdater) {

--- a/pkg/provisioner/ironic/update_opts.go
+++ b/pkg/provisioner/ironic/update_opts.go
@@ -160,3 +160,8 @@ func (nu *nodeUpdater) SetInstanceInfoOpts(settings optionsData, node *nodes.Nod
 	nu.setSectionUpdateOpts(node.InstanceInfo, settings, "/instance_info")
 	return nu
 }
+
+func (nu *nodeUpdater) SetDriverInfoOpts(settings optionsData, node *nodes.Node) *nodeUpdater {
+	nu.setSectionUpdateOpts(node.DriverInfo, settings, "/driver_info")
+	return nu
+}

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -337,12 +337,14 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 		DeployInterface string
 		Image           *metal3v1alpha1.Image
 		InstanceInfo    map[string]interface{}
+		DriverInfo      map[string]interface{}
 	}{
 		{
 			DeployInterface: "",
 			InstanceInfo: map[string]interface{}{
 				"capabilities": map[string]interface{}{},
 			},
+			DriverInfo: map[string]interface{}{},
 		},
 		{
 			DeployInterface: "direct",
@@ -357,6 +359,9 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 				"image_checksum":      "thechecksum",
 				"capabilities":        map[string]interface{}{},
 			},
+			DriverInfo: map[string]interface{}{
+				"force_persistent_boot_device": "Default",
+			},
 		},
 		{
 			DeployInterface: "ramdisk",
@@ -367,6 +372,9 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 			InstanceInfo: map[string]interface{}{
 				"boot_iso":     "theimage",
 				"capabilities": map[string]interface{}{},
+			},
+			DriverInfo: map[string]interface{}{
+				"force_persistent_boot_device": "Default",
 			},
 		},
 	}
@@ -392,6 +400,7 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 				InstanceUUID:    string(host.UID),
 				DeployInterface: imageType.DeployInterface,
 				InstanceInfo:    imageType.InstanceInfo,
+				DriverInfo:      imageType.DriverInfo,
 			}).NodeUpdate(nodes.Node{
 				UUID: "uuid",
 			})


### PR DESCRIPTION
When using format: live-iso, two distinct use-cases exist:
  - Boot an installer ISO (non-persistent one-time boot desired)
  - Boot an ISO appliance (persistent live-iso boot desired).

The original plan was to solve the installer-iso boot order via
uefibootmgr (running from the live-iso), but this doesn't work
reliably on all hardware.

So expose a variable to control this behavior - in future we may
want to consider a per-BMH variable, but for now expose a
per-BMO variable.