### PR TITLE
Bug 2000442: Add LIVE_ISO_FORCE_PERSISTENT_BOOT_DEVICE variable

### DIFF
--- a/pkg/provisioner/ironic/update_opts.go
+++ b/pkg/provisioner/ironic/update_opts.go
@@ -149,3 +149,8 @@ func (nu *nodeUpdater) SetInstanceInfoOpts(settings optionsData, node *nodes.Nod
 	nu.setSectionUpdateOpts(node.InstanceInfo, settings, "/instance_info")
 	return nu
 }
+
+func (nu *nodeUpdater) SetDriverInfoOpts(settings optionsData, node *nodes.Node) *nodeUpdater {
+	nu.setSectionUpdateOpts(node.DriverInfo, settings, "/driver_info")
+	return nu
+}

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -337,12 +337,14 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 		DeployInterface string
 		Image           *metal3v1alpha1.Image
 		InstanceInfo    map[string]interface{}
+		DriverInfo      map[string]interface{}
 	}{
 		{
 			DeployInterface: "",
 			InstanceInfo: map[string]interface{}{
 				"capabilities": map[string]interface{}{},
 			},
+			DriverInfo: map[string]interface{}{},
 		},
 		{
 			DeployInterface: "direct",
@@ -357,6 +359,9 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 				"image_checksum":      "thechecksum",
 				"capabilities":        map[string]interface{}{},
 			},
+			DriverInfo: map[string]interface{}{
+				"force_persistent_boot_device": "Default",
+			},
 		},
 		{
 			DeployInterface: "ramdisk",
@@ -367,6 +372,9 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 			InstanceInfo: map[string]interface{}{
 				"boot_iso":     "theimage",
 				"capabilities": map[string]interface{}{},
+			},
+			DriverInfo: map[string]interface{}{
+				"force_persistent_boot_device": "Default",
 			},
 		},
 	}
@@ -392,6 +400,7 @@ func TestValidateManagementAccessExistingSteadyStateNoUpdate(t *testing.T) {
 				InstanceUUID:    string(host.UID),
 				DeployInterface: imageType.DeployInterface,
 				InstanceInfo:    imageType.InstanceInfo,
+				DriverInfo:      imageType.DriverInfo,
 			}).NodeUpdate(nodes.Node{
 				UUID: "uuid",
 			})


### PR DESCRIPTION
When using format: live-iso, two distinct use-cases exist:
  - Boot an installer ISO (non-persistent one-time boot desired)
  - Boot an ISO appliance (persistent live-iso boot desired).

The original plan was to solve the installer-iso boot order via
uefibootmgr (running from the live-iso), but this doesn't work
reliably on all hardware.

So expose a variable to control this behavior - in future we may
want to consider a per-BMH variable, but for now expose a
per-BMO variable.

(cherry picked from commit 40fffc5094842631e180296533648c1b6bd59afd)
Conflicts:
    pkg/provisioner/ironic/ironic.go
    pkg/provisioner/ironic/update_opts.go