### PR TITLE
Updating ose-baremetal-operator images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.16
+  tag: rhel-8-release-golang-1.16-openshift-4.10


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/3dea8426481b269476342fc0a631273f32ce691e/images/ose-baremetal-operator.yml

This supersedes #177 