### PR TITLE
Update ocp_kustomization.yaml

### DIFF
--- a/config/crd/ocp/ocp_kustomization.yaml
+++ b/config/crd/ocp/ocp_kustomization.yaml
@@ -7,20 +7,27 @@ commonAnnotations:
 # It should be run by config/default
 resources:
 - bases/metal3.io_baremetalhosts.yaml
-- bases/metal3.io_firmwareschemas.yaml
 - bases/metal3.io_hostfirmwaresettings.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
+- bases/metal3.io_firmwareschemas.yaml
+- bases/metal3.io_preprovisioningimages.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_baremetalhosts.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+#- patches/webhook_in_hostfirmwaresettings.yaml
+#- patches/webhook_in_firmwareschemas.yaml
+#- patches/webhook_in_preprovisioningimages.yaml
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_baremetalhosts.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+#- patches/cainjection_in_hostfirmwaresettings.yaml
+#- patches/cainjection_in_firmwareschemas.yaml
+#- patches/cainjection_in_preprovisioningimages.yaml
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:


### PR DESCRIPTION
Sync with the upstream kustomize.yaml

This is necessary to annotate the PreprovisioningImage CRD for inclusion
in the CVO payload.