### PR TITLE
Bug 2035882: Publish events for all invalid HostFirmwareSettings

### DIFF
--- a/controllers/metal3.io/hostfirmwaresettings_controller.go
+++ b/controllers/metal3.io/hostfirmwaresettings_controller.go
@@ -340,13 +340,13 @@ func (r *HostFirmwareSettingsReconciler) validateHostFirmwareSettings(info *rInf
 		// Prohibit any Spec settings with "Password"
 		if strings.Contains(name, "Password") {
 			errors = append(errors, fmt.Errorf("Cannot set Password field"))
-			break
+			continue
 		}
 
 		// The setting must be in the Status
 		if _, ok := info.hfs.Status.Settings[name]; !ok {
 			errors = append(errors, fmt.Errorf("Setting %s is not in the Status field", name))
-			break
+			continue
 		}
 
 		// check validity of updated value


### PR DESCRIPTION
Publish events for all invalid settings, not just the first one found.