### PR TITLE
Bug 2044496: Update vendor

### DIFF
--- a/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/irmc.go
+++ b/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/irmc.go
@@ -75,7 +75,7 @@ func (a *iRMCAccessDetails) BIOSInterface() string {
 }
 
 func (a *iRMCAccessDetails) BootInterface() string {
-	return "pxe"
+	return "ipxe"
 }
 
 func (a *iRMCAccessDetails) ManagementInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/bmceventsubscription_webhook.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/bmceventsubscription_webhook.go
@@ -43,9 +43,22 @@ func (s *BMCEventSubscription) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+//
+// We prevent updates to the spec.  All other updates (e.g. status, finalizers) are allowed.
 func (s *BMCEventSubscription) ValidateUpdate(old runtime.Object) error {
 	bmcsubscriptionlog.Info("validate update", "name", s.Name)
-	return fmt.Errorf("subscriptions cannot be updated, please recreate it")
+
+	bes, casted := old.(*BMCEventSubscription)
+	if !casted {
+		bmcsubscriptionlog.Error(fmt.Errorf("old object conversion error"), "validate update error")
+		return nil
+	}
+
+	if s.Spec != bes.Spec {
+		return fmt.Errorf("subscriptions cannot be updated, please recreate it")
+	}
+
+	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type


### PR DESCRIPTION
PR #201 included a fix which isn't live because we haven't re-vendored the `api` module. This patch fixes it.