### PR TITLE
Bug 2047930: Move from Available to Preparing if HostFirmwareSettings changed

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -949,7 +949,7 @@ func (r *BareMetalHostReconciler) actionMatchProfile(prov provisioner.Provisione
 func (r *BareMetalHostReconciler) actionPreparing(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
 	info.log.Info("preparing")
 
-	dirty, newStatus, err := getHostProvisioningSettings(info.host)
+	bmhDirty, newStatus, err := getHostProvisioningSettings(info.host)
 	if err != nil {
 		return actionError{err}
 	}
@@ -960,49 +960,56 @@ func (r *BareMetalHostReconciler) actionPreparing(prov provisioner.Provisioner, 
 		RootDeviceHints:  newStatus.Provisioning.RootDeviceHints.DeepCopy(),
 		FirmwareConfig:   newStatus.Provisioning.Firmware.DeepCopy(),
 	}
-	// When manual cleaning fails, we think that the existed RAID configuration
+	// When manual cleaning fails, we think that the existing RAID configuration
 	// is invalid and needs to be reconfigured.
 	if info.host.Status.ErrorType == metal3v1alpha1.PreparationError {
 		prepareData.ActualRAIDConfig = nil
-		dirty = true
+		bmhDirty = true
 	}
 
-	// Use settings in hostFirmwareSettings if available
-	hfs, err := r.getHostFirmwareSettings(info)
+	// The hfsDirty flag is used to push the new settings to Ironic as part of the clean steps.
+	// The HFS Status field will be updated in the HostFirmwareSettingsReconciler when it reads the settings from Ironic.
+	// After manual cleaning is complete the HFS Spec should match the Status.
+	hfsDirty, hfs, err := r.getHostFirmwareSettings(info)
+
 	if err != nil {
 		// wait until hostFirmwareSettings are ready
 		return actionContinue{subResourceNotReadyRetryDelay}
 	}
-	if hfs != nil {
+	if hfsDirty {
 		prepareData.ActualFirmwareSettings = hfs.Status.Settings.DeepCopy()
 		prepareData.TargetFirmwareSettings = hfs.Spec.Settings.DeepCopy()
 	}
 
-	provResult, started, err := prov.Prepare(prepareData, dirty)
+	provResult, started, err := prov.Prepare(prepareData, bmhDirty || hfsDirty,
+		info.host.Status.ErrorType == metal3v1alpha1.PreparationError)
 
 	if err != nil {
 		return actionError{errors.Wrap(err, "error preparing host")}
 	}
 
 	if provResult.ErrorMessage != "" {
-		info.log.Info("handling cleaning error in controller")
-		clearHostProvisioningSettings(info.host)
+		if bmhDirty {
+			info.log.Info("handling cleaning error in controller")
+			clearHostProvisioningSettings(info.host)
+		}
 		return recordActionFailure(info, metal3v1alpha1.PreparationError, provResult.ErrorMessage)
 	}
 
-	if dirty && started {
+	if bmhDirty && started {
 		info.log.Info("saving host provisioning settings")
 		_, err := saveHostProvisioningSettings(info.host)
 		if err != nil {
 			return actionError{errors.Wrap(err, "could not save the host provisioning settings")}
 		}
 	}
+
 	if started && clearError(info.host) {
-		dirty = true
+		bmhDirty = true
 	}
 	if provResult.Dirty {
 		result := actionContinue{provResult.RequeueAfter}
-		if dirty {
+		if bmhDirty {
 			return actionUpdate{result}
 		}
 		return result
@@ -1378,34 +1385,35 @@ func (r *BareMetalHostReconciler) createHostFirmwareSettings(info *reconcileInfo
 }
 
 // Get the stored firmware settings if there are valid changes
-func (r *BareMetalHostReconciler) getHostFirmwareSettings(info *reconcileInfo) (hfs *metal3v1alpha1.HostFirmwareSettings, err error) {
+func (r *BareMetalHostReconciler) getHostFirmwareSettings(info *reconcileInfo) (dirty bool, hfs *metal3v1alpha1.HostFirmwareSettings, err error) {
 
 	hfs = &metal3v1alpha1.HostFirmwareSettings{}
 	if err = r.Get(context.TODO(), info.request.NamespacedName, hfs); err != nil {
 
 		if !k8serrors.IsNotFound(err) {
 			// Error reading the object
-			return nil, errors.Wrap(err, "could not load host firmware settings")
+			return false, nil, errors.Wrap(err, "could not load host firmware settings")
 		}
 
 		// Could not get settings, log it but don't return error as settings may not have been available at provisioner
 		info.log.Info("could not get hostFirmwareSettings", "namespacename", info.request.NamespacedName)
-		return nil, nil
+		return false, nil, nil
 	}
 
 	// Check if there are settings in the Spec that are different than the Status
 	if meta.IsStatusConditionTrue(hfs.Status.Conditions, string(metal3v1alpha1.FirmwareSettingsChangeDetected)) {
 
 		if meta.IsStatusConditionTrue(hfs.Status.Conditions, string(metal3v1alpha1.FirmwareSettingsValid)) {
-			return hfs, nil
+			info.log.Info("hostFirmwareSettings indicating ChangeDetected", "namespacename", info.request.NamespacedName)
+			return true, hfs, nil
 		}
 
 		info.log.Info("hostFirmwareSettings not valid", "namespacename", info.request.NamespacedName)
-		return nil, nil
+		return false, nil, nil
 	}
 
 	info.log.Info("hostFirmwareSettings no updates", "namespacename", info.request.NamespacedName)
-	return nil, nil
+	return false, nil, nil
 }
 
 func (r *BareMetalHostReconciler) saveHostStatus(host *metal3v1alpha1.BareMetalHost) error {

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,6 +76,31 @@ func newHost(name string, spec *metal3v1alpha1.BareMetalHostSpec) *metal3v1alpha
 		},
 		Spec: *spec,
 	}
+}
+
+func newHostFirmwareSettings(host *metal3v1alpha1.BareMetalHost, conditions []metav1.Condition) *metal3v1alpha1.HostFirmwareSettings {
+	hfs := &metal3v1alpha1.HostFirmwareSettings{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      host.Name,
+			Namespace: host.Namespace,
+		},
+		Spec: metal3v1alpha1.HostFirmwareSettingsSpec{
+			Settings: metal3v1alpha1.DesiredSettingsMap{
+				"ProcVirtualization": intstr.FromString("Disabled"),
+				"SecureBoot":         intstr.FromString("Enabled"),
+			},
+		},
+		Status: metal3v1alpha1.HostFirmwareSettingsStatus{
+			Settings: metal3v1alpha1.SettingsMap{
+				"ProcVirtualization": "Disabled",
+				"SecureBoot":         "Enabled",
+			},
+		},
+	}
+
+	hfs.Status.Conditions = conditions
+
+	return hfs
 }
 
 func newDefaultNamedHost(name string, t *testing.T) *metal3v1alpha1.BareMetalHost {
@@ -2518,4 +2544,116 @@ func TestPreprovImageAvailable(t *testing.T) {
 			assert.Equal(t, tc.Available, available)
 		})
 	}
+}
+
+// TestHostFirwmareSettings verifies that a change to the HFS
+// can be detected as it will be used to set state to Preparing
+func TestHostFirmwareSettings(t *testing.T) {
+
+	testCases := []struct {
+		Scenario   string
+		Conditions []metav1.Condition
+		Dirty      bool
+	}{
+		{
+			Scenario: "spec and status the same",
+			Conditions: []metav1.Condition{
+				{Type: "Valid", Status: "True", Reason: "Success"},
+			},
+			Dirty: false,
+		},
+		{
+			Scenario: "spec changed",
+			Conditions: []metav1.Condition{
+				{Type: "ChangeDetected", Status: "True", Reason: "Success"},
+				{Type: "Valid", Status: "True", Reason: "Success"},
+			},
+			Dirty: true,
+		},
+		{
+			Scenario: "spec invalid",
+			Conditions: []metav1.Condition{
+				{Type: "ChangeDetected", Status: "True", Reason: "Success"},
+				{Type: "Valid", Status: "False", Reason: "Success"},
+			},
+			Dirty: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			host := newDefaultHost(t)
+			r := newTestReconciler(host)
+			i := makeReconcileInfo(host)
+			i.request = newRequest(host)
+
+			hfs := newHostFirmwareSettings(host, tc.Conditions)
+			r.Create(goctx.TODO(), hfs)
+
+			dirty, _, err := r.getHostFirmwareSettings(i)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.Dirty, dirty, "dirty flag did not match")
+		})
+	}
+
+}
+
+func TestBMHTransitionToPreparing(t *testing.T) {
+	var True = true
+	var False = false
+	host := newDefaultHost(t)
+	host.Spec.Online = true
+	host.Spec.ExternallyProvisioned = false
+	host.Spec.ConsumerRef = &corev1.ObjectReference{}
+	r := newTestReconciler(host)
+
+	waitForProvisioningState(t, r, host, metal3v1alpha1.StateAvailable)
+
+	// use different values between spec and status to force cleaning
+	host.Status.Provisioning.Firmware = &metal3v1alpha1.FirmwareConfig{
+		VirtualizationEnabled:             &True,
+		SimultaneousMultithreadingEnabled: &False,
+	}
+	host.Spec.Firmware = &metal3v1alpha1.FirmwareConfig{
+		VirtualizationEnabled:             &False,
+		SimultaneousMultithreadingEnabled: &True,
+	}
+
+	err := r.Update(goctx.TODO(), host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitForProvisioningState(t, r, host, metal3v1alpha1.StatePreparing)
+}
+
+func TestHFSTransitionToPreparing(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Spec.Online = true
+	host.Spec.ConsumerRef = &corev1.ObjectReference{}
+	host.Spec.ExternallyProvisioned = false
+	r := newTestReconciler(host)
+
+	waitForProvisioningState(t, r, host, metal3v1alpha1.StateAvailable)
+
+	// Update HFS so host will go through cleaning
+	hfs := &metal3v1alpha1.HostFirmwareSettings{}
+	key := client.ObjectKey{
+		Namespace: host.ObjectMeta.Namespace, Name: host.ObjectMeta.Name}
+	if err := r.Get(goctx.TODO(), key, hfs); err != nil {
+		t.Fatal(err)
+	}
+
+	hfs.Status = metal3v1alpha1.HostFirmwareSettingsStatus{
+		Conditions: []metav1.Condition{
+			{Type: "ChangeDetected", Status: "True", Reason: "Success"},
+			{Type: "Valid", Status: "True", Reason: "Success"},
+		},
+	}
+
+	r.Update(goctx.TODO(), hfs)
+
+	waitForProvisioningState(t, r, host, metal3v1alpha1.StatePreparing)
 }

--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -419,6 +419,14 @@ func (hsm *hostStateMachine) handleAvailable(info *reconcileInfo) actionResult {
 		return actionComplete{}
 	}
 
+	// Check if hostFirmwareSettings have changed
+	if dirty, _, err := hsm.Reconciler.getHostFirmwareSettings(info); err != nil {
+		return actionError{err}
+	} else if dirty {
+		hsm.NextState = metal3v1alpha1.StatePreparing
+		return actionComplete{}
+	}
+
 	// ErrorCount is cleared when appropriate inside actionManageAvailable
 	actResult := hsm.Reconciler.actionManageAvailable(hsm.Provisioner, info)
 	if _, complete := actResult.(actionComplete); complete {

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -1239,7 +1239,7 @@ func (m *mockProvisioner) UpdateHardwareState() (hwState provisioner.HardwareSta
 	return
 }
 
-func (m *mockProvisioner) Prepare(data provisioner.PrepareData, unprepared bool) (result provisioner.Result, started bool, err error) {
+func (m *mockProvisioner) Prepare(data provisioner.PrepareData, unprepared bool, force bool) (result provisioner.Result, started bool, err error) {
 	return m.getNextResultByMethod("Prepare"), m.nextResults["Prepare"].Dirty, err
 }
 

--- a/controllers/metal3.io/hostfirmwaresettings_controller.go
+++ b/controllers/metal3.io/hostfirmwaresettings_controller.go
@@ -41,9 +41,10 @@ import (
 )
 
 const (
-	provisionerRetryDelay          = time.Second * 30
-	resourceNotAvailableRetryDelay = time.Second * 30
-	reconcilerRequeueDelay         = time.Minute * 5
+	provisionerRetryDelay                = time.Second * 30
+	resourceNotAvailableRetryDelay       = time.Second * 30
+	reconcilerRequeueDelay               = time.Minute * 5
+	reconcilerRequeueDelayChangeDetected = time.Minute * 1
 )
 
 // HostFirmwareSettingsReconciler reconciles a HostFirmwareSettings object
@@ -162,6 +163,10 @@ func (r *HostFirmwareSettingsReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	// requeue to run again after delay
+	if meta.IsStatusConditionTrue(info.hfs.Status.Conditions, string(metal3v1alpha1.FirmwareSettingsChangeDetected)) {
+		// If there is a difference between Spec and Status shorten the query from Ironic so that the Status is updated when cleaning completes
+		return ctrl.Result{Requeue: true, RequeueAfter: reconcilerRequeueDelayChangeDetected}, nil
+	}
 	return ctrl.Result{Requeue: true, RequeueAfter: reconcilerRequeueDelay}, nil
 }
 

--- a/controllers/metal3.io/hostfirmwaresettings_test.go
+++ b/controllers/metal3.io/hostfirmwaresettings_test.go
@@ -75,7 +75,7 @@ func (m *hsfMockProvisioner) UpdateHardwareState() (hwState provisioner.Hardware
 	return
 }
 
-func (m *hsfMockProvisioner) Prepare(data provisioner.PrepareData, unprepared bool) (result provisioner.Result, started bool, err error) {
+func (m *hsfMockProvisioner) Prepare(data provisioner.PrepareData, unprepared bool, force bool) (result provisioner.Result, started bool, err error) {
 	return
 }
 

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -193,7 +193,7 @@ func (p *demoProvisioner) UpdateHardwareState() (hwState provisioner.HardwareSta
 }
 
 // Prepare remove existing configuration and set new configuration
-func (p *demoProvisioner) Prepare(data provisioner.PrepareData, unprepared bool) (result provisioner.Result, started bool, err error) {
+func (p *demoProvisioner) Prepare(data provisioner.PrepareData, unprepared bool, force bool) (result provisioner.Result, started bool, err error) {
 	hostName := p.objectMeta.Name
 
 	switch hostName {

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -191,7 +191,7 @@ func (p *fixtureProvisioner) UpdateHardwareState() (hwState provisioner.Hardware
 }
 
 // Prepare remove existing configuration and set new configuration
-func (p *fixtureProvisioner) Prepare(data provisioner.PrepareData, unprepared bool) (result provisioner.Result, started bool, err error) {
+func (p *fixtureProvisioner) Prepare(data provisioner.PrepareData, unprepared bool, force bool) (result provisioner.Result, started bool, err error) {
 	p.log.Info("preparing host")
 	started = unprepared
 	return

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1257,7 +1257,7 @@ func (p *ironicProvisioner) startManualCleaning(bmcAccess bmc.AccessDetails, iro
 
 // Prepare remove existing configuration and set new configuration.
 // If `started` is true,  it means that we successfully executed `tryChangeNodeProvisionState`.
-func (p *ironicProvisioner) Prepare(data provisioner.PrepareData, unprepared bool) (result provisioner.Result, started bool, err error) {
+func (p *ironicProvisioner) Prepare(data provisioner.PrepareData, unprepared bool, force bool) (result provisioner.Result, started bool, err error) {
 	bmcAccess, err := p.bmcAccess()
 	if err != nil {
 		result, err = transientError(err)
@@ -1308,9 +1308,9 @@ func (p *ironicProvisioner) Prepare(data provisioner.PrepareData, unprepared boo
 
 	case nodes.CleanFail:
 		// When clean failed, we need to clean host provisioning settings.
-		// If unprepared is false, means the settings aren't cleared.
+		// If force is false, it means the settings aren't cleared.
 		// So we can't set the node's state to manageable, until the settings are cleared.
-		if !unprepared {
+		if !force {
 			result, err = operationFailed(ironicNode.LastError)
 			return
 		}

--- a/pkg/provisioner/ironic/prepare_test.go
+++ b/pkg/provisioner/ironic/prepare_test.go
@@ -207,7 +207,7 @@ func TestPrepare(t *testing.T) {
 				t.Fatalf("could not create provisioner: %s", err)
 			}
 
-			result, started, err := prov.Prepare(prepData, tc.unprepared)
+			result, started, err := prov.Prepare(prepData, tc.unprepared, tc.unprepared)
 
 			assert.Equal(t, tc.expectedStarted, started)
 			assert.Equal(t, tc.expectedDirty, result.Dirty)

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -148,7 +148,7 @@ type Provisioner interface {
 	Adopt(data AdoptData, force bool) (result Result, err error)
 
 	// Prepare remove existing configuration and set new configuration
-	Prepare(data PrepareData, unprepared bool) (result Result, started bool, err error)
+	Prepare(data PrepareData, unprepared bool, force bool) (result Result, started bool, err error)
 
 	// Provision writes the image from the host spec to the host. It
 	// may be called multiple times, and should return true for its


### PR DESCRIPTION
Currently if the host is in the Available state and the HFS settings are
changed it doesn't transition to the Preparing state as it would when the
BareMetalHost settings are changed. This change fixes that.

(cherry picked from commit cd3340b20de240feb1566432def9fc6b678f7626)