### PR TITLE
Enable multi-arch builds

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
 WORKDIR /go/src/github.com/metal3-io/baremetal-operator
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/baremetal-operator main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o bin/baremetal-operator main.go
 RUN make tools
 RUN make tools/bin/kustomize
 


### PR DESCRIPTION
Remove `amd64` from go binary builds, this breaks arm64 builds.

https://issues.redhat.com/browse/ARMOCP-324

upstream: https://github.com/metal3-io/baremetal-operator/pull/1097