### PR TITLE
Move bmh crd to level 31

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -8,7 +8,7 @@ RUN make tools/bin/kustomize
 RUN cp /go/src/github.com/metal3-io/baremetal-operator/config/crd/ocp/ocp_kustomization.yaml /go/src/github.com/metal3-io/baremetal-operator/config/crd/kustomization.yaml &&\
     tools/bin/kustomize build config/crd > config/crd/baremetalhost.crd.yaml &&\
     mkdir /go/src/github.com/metal3-io/baremetal-operator/manifests &&\
-    cp /go/src/github.com/metal3-io/baremetal-operator/config/crd/baremetalhost.crd.yaml /go/src/github.com/metal3-io/baremetal-operator/manifests/0000_30_baremetal-operator_01_baremetalhost.crd.yaml
+    cp /go/src/github.com/metal3-io/baremetal-operator/config/crd/baremetalhost.crd.yaml /go/src/github.com/metal3-io/baremetal-operator/manifests/0000_31_cluster-baremetal-operator_00_baremetalhost.crd.yaml
 
 FROM registry.ci.openshift.org/ocp/4.11:base
 COPY --from=builder /go/src/github.com/metal3-io/baremetal-operator/bin/baremetal-operator /


### PR DESCRIPTION
We move the baremetalhost crd to level 31 where the rest of the CBO
manifests reside.  We set it at 00 to ensure it's installed first as per
the initial intention.

This patch ensures that all CBO manifests are collected into a single
task node during updates.