### PR TITLE
[OCP] Disable iDRAC RAID

### DIFF
--- a/pkg/hardwareutils/bmc/idrac_virtualmedia.go
+++ b/pkg/hardwareutils/bmc/idrac_virtualmedia.go
@@ -85,7 +85,9 @@ func (a *redfishiDracVirtualMediaAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) RAIDInterface() string {
-	return "idrac-redfish"
+	// Disabled RAID in OpenShift because we are not ready to support it
+	// return "idrac-redfish"
+	return "no-raid"
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) VendorInterface() string {

--- a/pkg/hardwareutils/bmc/redfish.go
+++ b/pkg/hardwareutils/bmc/redfish.go
@@ -164,7 +164,9 @@ func (a *redfishiDracAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracAccessDetails) RAIDInterface() string {
-	return "idrac-redfish"
+	// Disabled RAID in OpenShift because we are not ready to support it
+	// return "idrac-redfish"
+	return "no-raid"
 }
 
 func (a *redfishiDracAccessDetails) VendorInterface() string {


### PR DESCRIPTION
It was disabled for all drivers in e2d5a7591c5abf751331a0e111e29f1b519c0e11,
but appeared in recent upstream changes for iDRAC-Redfish.
