### PR TITLE
Bug 2092650: Stop treating missing network as fatal error

### DIFF
--- a/controllers/metal3.io/host_config_data.go
+++ b/controllers/metal3.io/host_config_data.go
@@ -79,11 +79,19 @@ func (hcd *hostConfigData) NetworkData() (string, error) {
 	if namespace == "" {
 		namespace = hcd.host.Namespace
 	}
-	return hcd.getSecretData(
+	networkDataRaw, err := hcd.getSecretData(
 		networkData.Name,
 		namespace,
 		"networkData",
 	)
+	if err != nil {
+		_, isNoDataErr := err.(NoDataInSecretError)
+		if isNoDataErr {
+			hcd.log.Info("NetworkData key is not set, returning empty data")
+			return "", nil
+		}
+	}
+	return networkDataRaw, err
 }
 
 // MetaData get host metatdata


### PR DESCRIPTION
Report that NetworkData isn't available and return a
blank string id the sectret is present but doesn't contain
the expected key. This is the same as the behaviour when the
secret isn't present at all.