### PR TITLE
Bug 2087213: Don't require PreprovisioningImages for older ZTP

### DIFF
--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -299,6 +299,12 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 		// In the deleting state the whole idea is to de-register the host
 		return
 	case metal3v1alpha1.StateRegistering:
+	case metal3v1alpha1.StateInspecting:
+		if inspectionDisabled(hsm.Host) {
+			// No need to register if we are not actually going to inspect
+			return
+		}
+		fallthrough
 	default:
 		if hsm.Host.Status.ErrorType == metal3v1alpha1.RegistrationError ||
 			!hsm.Host.Status.GoodCredentials.Match(*info.bmcCredsSecret) {


### PR DESCRIPTION
Calling `registerHost()` in the Inspecting or Preparing states will require that we have a PreprovisioningImage built before we proceed.

machine-image-customization-controller does not reconcile images with the an InfraEnv label for ZTP. Versions > RHACM 2.4 supply a separate controller that reconciles these resources, but earlier versions do not. Earlier versions also disable inspection and do not use any of the features of the Preparing state, so it is safe to simply avoid calling `registerHost()` in these states for these hosts.