### PR TITLE
Bug 2087213: Don't require pre-provisioning image for live ISO provisioning

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -523,9 +523,14 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 
 	default:
 		switch data.State {
+		case metal3v1alpha1.StateProvisioning:
+			if data.CurrentImage.IsLiveISO() {
+				// Live ISO doesn't need pre-provisioning image
+				return
+			}
+			fallthrough
 		case metal3v1alpha1.StateInspecting,
 			metal3v1alpha1.StatePreparing,
-			metal3v1alpha1.StateProvisioning,
 			metal3v1alpha1.StateDeprovisioning:
 			if deployImageInfo == nil {
 				if p.config.havePreprovImgBuilder {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -523,15 +523,22 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 
 	default:
 		switch data.State {
-		case metal3v1alpha1.StateProvisioning:
-			if data.CurrentImage.IsLiveISO() {
-				// Live ISO doesn't need pre-provisioning image
-				return
+		case metal3v1alpha1.StateProvisioning,
+			metal3v1alpha1.StateDeprovisioning:
+			if data.State == metal3v1alpha1.StateProvisioning {
+				if data.CurrentImage.IsLiveISO() {
+					// Live ISO doesn't need pre-provisioning image
+					return
+				}
+			} else {
+				if data.AutomatedCleaningMode == metal3v1alpha1.CleaningModeDisabled {
+					// No need for pre-provisioning image if cleaning disabled
+					return
+				}
 			}
 			fallthrough
 		case metal3v1alpha1.StateInspecting,
-			metal3v1alpha1.StatePreparing,
-			metal3v1alpha1.StateDeprovisioning:
+			metal3v1alpha1.StatePreparing:
 			if deployImageInfo == nil {
 				if p.config.havePreprovImgBuilder {
 					result, err = transientError(provisioner.ErrNeedsPreprovisioningImage)


### PR DESCRIPTION
The live-iso provisioning method does not require IPA to be booted on
the server, so don't fail if there is no PreprovisioningImage available.

(cherry picked from commit 8577aac3928b4d86e04414bbe976d0e51d961cf1)