### PR TITLE
🐛  allow namespace to continue with terminating when bmh is deprovisioning at the same time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ ironic-inspector-auth-config
 ironic-rpc-auth-config
 HTTP_BASIC_HTPASSWD
 ironic-deployment/overlays/temp
+
+# macOS generated
+.DS_Store
+
+# jetbrains generated
+.idea


### PR DESCRIPTION
When BMH is deleted and NS is also in terminating state around the same time (usually GitOps/ArgoCD is involved), BMO may not be able to creating additional CRs as part of the deprovisioning steps. This condition essentially hangs the cleanup of BMH, its Secret (used for BMC) while the NS stays at a terminating state. 

/cc @dtantsur 
/cc @rhjanders 