### PR TITLE
OCPBUGS-11870: Create nodes with namespace already prepended

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -373,7 +373,7 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 				Driver:              bmcAccess.Driver(),
 				BIOSInterface:       bmcAccess.BIOSInterface(),
 				BootInterface:       bmcAccess.BootInterface(),
-				Name:                p.objectMeta.Name,
+				Name:                ironicNodeName(p.objectMeta),
 				DriverInfo:          driverInfo,
 				DeployInterface:     p.deployInterface(data),
 				InspectInterface:    "inspector",


### PR DESCRIPTION
For some reason, BMO creates nodes without the namespace~ prefix, then
updates them. This may cause conflicts between nodes belong to hosts
from different namespaces.

(cherry picked from commit bca45815ea101c99669a8552411cc7b827f5bbaa)
