### PR TITLE
OCPBUGS-11310: Revert live-iso validation

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -76,7 +76,6 @@ func (host *BareMetalHost) validateChanges(old *BareMetalHost) []error {
 
 func validateBMCAccess(s BareMetalHostSpec, bmcAccess bmc.AccessDetails) []error {
 	var errs []error
-	diskFormat := "live-iso"
 
 	if bmcAccess == nil {
 		return errs
@@ -107,10 +106,6 @@ func validateBMCAccess(s BareMetalHostSpec, bmcAccess bmc.AccessDetails) []error
 
 	if s.BootMode == UEFISecureBoot && !bmcAccess.SupportsSecureBoot() {
 		errs = append(errs, fmt.Errorf("BMC driver %s does not support secure boot", bmcAccess.Type()))
-	}
-
-	if s.Image != nil && s.Image.DiskFormat != nil && *s.Image.DiskFormat == diskFormat && !bmcAccess.SupportsISOPreprovisioningImage() {
-		errs = append(errs, fmt.Errorf("BMC driver %s does not support live-iso image", bmcAccess.Type()))
 	}
 
 	return errs

--- a/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -46,7 +46,6 @@ func TestValidateCreate(t *testing.T) {
 
 	// for RAID validation test cases
 	numberOfPhysicalDisks := 3
-	diskFormat := "live-iso"
 
 	tests := []struct {
 		name      string
@@ -455,25 +454,6 @@ func TestValidateCreate(t *testing.T) {
 			},
 			oldBMH:    nil,
 			wantedErr: "Image URL test1 is an invalid URL",
-		},
-		{
-			name: "liveISOImageWithUnsupportedBMC",
-			newBMH: &BareMetalHost{
-				TypeMeta:   tm,
-				ObjectMeta: om,
-				Spec: BareMetalHostSpec{
-					BMC: BMCDetails{
-						Address:         "idrac://127.0.0.1",
-						CredentialsName: "test1",
-					},
-					Image: &Image{
-						URL:        "http://127.0.0.1",
-						DiskFormat: &diskFormat,
-					},
-				}, // end of BMH spec
-			},
-			oldBMH:    nil,
-			wantedErr: "BMC driver idrac does not support live-iso image",
 		},
 	}
 

--- a/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -76,7 +76,6 @@ func (host *BareMetalHost) validateChanges(old *BareMetalHost) []error {
 
 func validateBMCAccess(s BareMetalHostSpec, bmcAccess bmc.AccessDetails) []error {
 	var errs []error
-	diskFormat := "live-iso"
 
 	if bmcAccess == nil {
 		return errs
@@ -107,10 +106,6 @@ func validateBMCAccess(s BareMetalHostSpec, bmcAccess bmc.AccessDetails) []error
 
 	if s.BootMode == UEFISecureBoot && !bmcAccess.SupportsSecureBoot() {
 		errs = append(errs, fmt.Errorf("BMC driver %s does not support secure boot", bmcAccess.Type()))
-	}
-
-	if s.Image != nil && s.Image.DiskFormat != nil && *s.Image.DiskFormat == diskFormat && !bmcAccess.SupportsISOPreprovisioningImage() {
-		errs = append(errs, fmt.Errorf("BMC driver %s does not support live-iso image", bmcAccess.Type()))
 	}
 
 	return errs


### PR DESCRIPTION
This validation is blocking pxe booting when live-iso image format is used along with non-virtualmedia drivers.

Cherry picks e257729ed8d2eff2c62e5591bc2e515c1ed93489