### PR TITLE
OCPBUGS-12828: [release 4.13] Store htpasswd files in Secrets instead of ConfigMaps

### DIFF
--- a/ironic-deployment/components/basic-auth/auth.yaml
+++ b/ironic-deployment/components/basic-auth/auth.yaml
@@ -14,7 +14,7 @@ spec:
           readOnly: true
         envFrom:
         # This is the htpassword matching the ironic-auth-config that inspector has
-        - configMapRef:
+        - secretRef:
             name: ironic-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
@@ -26,7 +26,7 @@ spec:
           readOnly: true
         envFrom:
         # This is the htpassword matching the ironic-inspector-auth-config that ironic has
-        - configMapRef:
+        - secretRef:
             name: ironic-inspector-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap

--- a/ironic-deployment/components/basic-auth/kustomization.yaml
+++ b/ironic-deployment/components/basic-auth/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-configMapGenerator:
+secretGenerator:
 - behavior: create
   envs:
   - ironic-htpasswd
@@ -10,8 +10,6 @@ configMapGenerator:
   envs:
   - ironic-inspector-htpasswd
   name: ironic-inspector-htpasswd
-
-secretGenerator:
 - name: ironic-auth-config
   files:
   - auth-config=ironic-auth-config

--- a/ironic-deployment/overlays/basic-auth_tls/basic-auth_tls.yaml
+++ b/ironic-deployment/overlays/basic-auth_tls/basic-auth_tls.yaml
@@ -8,9 +8,9 @@ spec:
       containers:
       - name: ironic-httpd
         envFrom:
-        - configMapRef:
+        - secretRef:
             name: ironic-htpasswd
-        - configMapRef:
+        - secretRef:
             name: ironic-inspector-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap


### PR DESCRIPTION
(cherry picked from commit https://github.com/openshift/baremetal-operator/commit/a58a905cccd69284e13eda3db4da07ef2c707aad)