### PR TITLE
[release-4.13] OCPBUGS-13082: Allow by-path devices in root device hints

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -52,8 +52,9 @@ const (
 // RootDeviceHints holds the hints for specifying the storage location
 // for the root filesystem for the image.
 type RootDeviceHints struct {
-	// A Linux device name like "/dev/vda". The hint must match the
-	// actual value exactly.
+	// A Linux device name like "/dev/vda", or a by-path link to it like
+	// "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0". The hint must match
+	// the actual value exactly.
 	DeviceName string `json:"deviceName,omitempty"`
 
 	// A SCSI bus address like 0:0:0:0. The hint must match the actual

--- a/config/crd/bases/metal3.io_baremetalhosts.yaml
+++ b/config/crd/bases/metal3.io_baremetalhosts.yaml
@@ -374,7 +374,8 @@ spec:
                               image.
                             properties:
                               deviceName:
-                                description: A Linux device name like "/dev/vda".
+                                description: A Linux device name like "/dev/vda",
+                                  or a by-path link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
                                   The hint must match the actual value exactly.
                                 type: string
                               hctl:
@@ -436,8 +437,9 @@ spec:
                   image being provisioned.
                 properties:
                   deviceName:
-                    description: A Linux device name like "/dev/vda". The hint must
-                      match the actual value exactly.
+                    description: A Linux device name like "/dev/vda", or a by-path
+                      link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
+                      The hint must match the actual value exactly.
                     type: string
                   hctl:
                     description: A SCSI bus address like 0:0:0:0. The hint must match
@@ -977,7 +979,8 @@ spec:
                                   the image.
                                 properties:
                                   deviceName:
-                                    description: A Linux device name like "/dev/vda".
+                                    description: A Linux device name like "/dev/vda",
+                                      or a by-path link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
                                       The hint must match the actual value exactly.
                                     type: string
                                   hctl:
@@ -1039,8 +1042,9 @@ spec:
                     description: The RootDevicehints set by the user
                     properties:
                       deviceName:
-                        description: A Linux device name like "/dev/vda". The hint
-                          must match the actual value exactly.
+                        description: A Linux device name like "/dev/vda", or a by-path
+                          link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
+                          The hint must match the actual value exactly.
                         type: string
                       hctl:
                         description: A SCSI bus address like 0:0:0:0. The hint must

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -373,7 +373,8 @@ spec:
                               image.
                             properties:
                               deviceName:
-                                description: A Linux device name like "/dev/vda".
+                                description: A Linux device name like "/dev/vda",
+                                  or a by-path link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
                                   The hint must match the actual value exactly.
                                 type: string
                               hctl:
@@ -435,8 +436,9 @@ spec:
                   image being provisioned.
                 properties:
                   deviceName:
-                    description: A Linux device name like "/dev/vda". The hint must
-                      match the actual value exactly.
+                    description: A Linux device name like "/dev/vda", or a by-path
+                      link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
+                      The hint must match the actual value exactly.
                     type: string
                   hctl:
                     description: A SCSI bus address like 0:0:0:0. The hint must match
@@ -976,7 +978,8 @@ spec:
                                   the image.
                                 properties:
                                   deviceName:
-                                    description: A Linux device name like "/dev/vda".
+                                    description: A Linux device name like "/dev/vda",
+                                      or a by-path link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
                                       The hint must match the actual value exactly.
                                     type: string
                                   hctl:
@@ -1038,8 +1041,9 @@ spec:
                     description: The RootDevicehints set by the user
                     properties:
                       deviceName:
-                        description: A Linux device name like "/dev/vda". The hint
-                          must match the actual value exactly.
+                        description: A Linux device name like "/dev/vda", or a by-path
+                          link to it like "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0".
+                          The hint must match the actual value exactly.
                         type: string
                       hctl:
                         description: A SCSI bus address like 0:0:0:0. The hint must

--- a/pkg/provisioner/ironic/devicehints/devicehints.go
+++ b/pkg/provisioner/ironic/devicehints/devicehints.go
@@ -2,6 +2,7 @@ package devicehints
 
 import (
 	"fmt"
+	"strings"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
@@ -16,7 +17,11 @@ func MakeHintMap(source *metal3v1alpha1.RootDeviceHints) map[string]string {
 	}
 
 	if source.DeviceName != "" {
-		hints["name"] = fmt.Sprintf("s== %s", source.DeviceName)
+		if strings.HasPrefix(source.DeviceName, "/dev/disk/by-path/") {
+			hints["by_path"] = fmt.Sprintf("s== %s", source.DeviceName)
+		} else {
+			hints["name"] = fmt.Sprintf("s== %s", source.DeviceName)
+		}
 	}
 	if source.HCTL != "" {
 		hints["hctl"] = fmt.Sprintf("s== %s", source.HCTL)

--- a/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
+++ b/pkg/provisioner/ironic/hardwaredetails/hardwaredetails.go
@@ -110,8 +110,12 @@ func getDiskType(diskdata introspection.RootDiskType) metal3v1alpha1.DiskType {
 func getStorageDetails(diskdata []introspection.RootDiskType) []metal3v1alpha1.Storage {
 	storage := make([]metal3v1alpha1.Storage, len(diskdata))
 	for i, disk := range diskdata {
+		device := disk.Name
+		if disk.ByPath != "" {
+			device = disk.ByPath
+		}
 		storage[i] = metal3v1alpha1.Storage{
-			Name:               disk.Name,
+			Name:               device,
 			Rotational:         disk.Rotational,
 			Type:               getDiskType(disk),
 			SizeBytes:          metal3v1alpha1.Capacity(disk.Size),

--- a/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -52,8 +52,9 @@ const (
 // RootDeviceHints holds the hints for specifying the storage location
 // for the root filesystem for the image.
 type RootDeviceHints struct {
-	// A Linux device name like "/dev/vda". The hint must match the
-	// actual value exactly.
+	// A Linux device name like "/dev/vda", or a by-path link to it like
+	// "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0". The hint must match
+	// the actual value exactly.
 	DeviceName string `json:"deviceName,omitempty"`
 
 	// A SCSI bus address like 0:0:0:0. The hint must match the actual


### PR DESCRIPTION
Allow a `/dev/disk/by-path/*` path to be specified in root device hints. Also, use this path in inspection results to ensure that paths are stable across reboots, since with the RHEL 9 kernel the actual kernel device filenames are much less stable than they were in RHEL 8.