### PR TITLE
OCPBUGS-7581: Deleting unmanaged BMH get stuck fix

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -335,10 +335,9 @@ func recordActionFailure(info *reconcileInfo, errorType metal3v1alpha1.ErrorType
 func recordActionDelayed(info *reconcileInfo, state metal3v1alpha1.ProvisioningState) actionResult {
 	var counter prometheus.Counter
 
-	switch state {
-	case metal3v1alpha1.StateDeprovisioning, metal3v1alpha1.StateDeleting:
+	if state == metal3v1alpha1.StateDeprovisioning {
 		counter = delayedDeprovisioningHostCounters.With(hostMetricLabels(info.request))
-	default:
+	} else {
 		counter = delayedProvisioningHostCounters.With(hostMetricLabels(info.request))
 	}
 

--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -104,7 +104,7 @@ func (hsm *hostStateMachine) updateHostStateFrom(initialState metal3v1alpha1.Pro
 		// avoid putting an excessive pressure on the provisioner
 		switch hsm.NextState {
 		case metal3v1alpha1.StateInspecting, metal3v1alpha1.StateProvisioning,
-			metal3v1alpha1.StateDeprovisioning, metal3v1alpha1.StateDeleting:
+			metal3v1alpha1.StateDeprovisioning:
 			if actionRes := hsm.ensureCapacity(info, hsm.NextState); actionRes != nil {
 				return actionRes
 			}
@@ -161,7 +161,7 @@ func (hsm *hostStateMachine) checkDelayedHost(info *reconcileInfo) actionResult 
 	// host not yet tracked by the provisioner
 	switch info.host.Status.Provisioning.State {
 	case metal3v1alpha1.StateInspecting, metal3v1alpha1.StateProvisioning,
-		metal3v1alpha1.StateDeprovisioning, metal3v1alpha1.StateDeleting:
+		metal3v1alpha1.StateDeprovisioning:
 		if actionRes := hsm.ensureCapacity(info, info.host.Status.Provisioning.State); actionRes != nil {
 			return actionRes
 		}

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -187,14 +187,6 @@ func TestDeprovisioningCapacity(t *testing.T) {
 			ExpectedDeprovisioningState: metal3v1alpha1.StateAvailable,
 			ExpectedDelayed:             false,
 		},
-		{
-			Scenario:                  "transition-to-deleting",
-			Host:                      host(metal3v1alpha1.StateDeprovisioning).setDeletion().build(),
-			HasDeprovisioningCapacity: true,
-
-			ExpectedDeprovisioningState: metal3v1alpha1.StateDeleting,
-			ExpectedDelayed:             false,
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This fixes the issue of deleting "unmanaged" BMH getting stuck in that state.

Cherry picks [upstream BMO PR-1259](https://github.com/metal3-io/baremetal-operator/pull/1259/commits)