### PR TITLE
OCPBUGS-13374: Do not try to update images for nodes in transient states

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -504,17 +504,18 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 		result, err = operationContinuing(provisionRequeueDelay)
 		return
 
+	case nodes.CleanWait,
+		nodes.Cleaning,
+		nodes.DeployWait,
+		nodes.Deploying,
+		nodes.Inspecting:
+		// Do not try to update the node if it's in a transient state other than InspectWait - will fail anyway.
+		result, err = operationComplete()
+		return
+
 	case nodes.Active:
 		// The host is already running, maybe it's a controlplane host?
 		p.debugLog.Info("have active host", "image_source", ironicNode.InstanceInfo["image_source"])
-		fallthrough
-
-	case nodes.Manageable:
-		fallthrough
-
-	case nodes.Available:
-		// The host is fully registered (and probably wasn't cleanly
-		// deleted previously)
 		fallthrough
 
 	default:

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -458,6 +458,7 @@ func TestValidateManagementAccessExistingNodeWaiting(t *testing.T) {
 	statuses := []nodes.ProvisionState{
 		nodes.Enroll,
 		nodes.Verifying,
+		nodes.Manageable,
 		nodes.Inspecting,
 	}
 
@@ -506,13 +507,18 @@ func TestValidateManagementAccessExistingNodeWaiting(t *testing.T) {
 			}
 			assert.Equal(t, "", result.ErrorMessage)
 
-			if status == nodes.Inspecting {
+			switch status {
+			case nodes.Manageable:
 				assert.False(t, result.Dirty)
 				updates := ironic.GetLastNodeUpdateRequestFor("uuid")
 				assert.Len(t, updates, 1)
 				assert.Equal(t, "/automated_clean", updates[0].Path)
 				assert.Equal(t, true, updates[0].Value)
-			} else {
+
+			case nodes.Inspecting:
+				assert.False(t, result.Dirty)
+
+			default:
 				assert.True(t, result.Dirty)
 			}
 		})


### PR DESCRIPTION
Currently, if e.g. the deploy ISO has changed, BMO will try to update
the node. Such updates cannot work in most transient states, causing
the reconciler to return early with an error.

(cherry picked from commit 65bf31df7f9289d88c56d15bc87962d3b42fae69)
