### PR TITLE
Stop linting when building the image

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/metal3-io/baremetal-operator
 COPY . .
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o bin/baremetal-operator main.go
+RUN make manager
 RUN make tools
 RUN make tools/bin/kustomize
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ manifest-lint: ## Run manifest validation
 build: generate manifests manager tools ## Build everything
 
 .PHONY: manager
-manager: generate lint ## Build manager binary
+manager: ## Build manager binary
 	go build -ldflags $(LDFLAGS) -o bin/$(OPERATOR_NAME) main.go
 
 .PHONY: run


### PR DESCRIPTION
When we build the image, the code has already been through code review, and CI. Everything has been generated, and linted, and addressed. At the build stage, we just want to compile the binary.

Furthermore, the golangci-lint program seems to require attention every time we upgrade Go in the builder. This breaks the build, and we have to do emergency upgrades to get it unstuck.

Lastly, we use the Makefile target `manager` instead of the low-level Go command.  This gives us build-time information in the binary.