### PR TITLE
[release-4.13] OCPBUGS-17365: Trigger reconcile on Secret change

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -40,7 +40,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
@@ -1740,7 +1742,8 @@ func (r *BareMetalHostReconciler) SetupWithManager(mgr ctrl.Manager, preprovImgE
 				UpdateFunc: r.updateEventHandler,
 			}).
 		WithOptions(opts).
-		Owns(&corev1.Secret{})
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			&handler.EnqueueRequestForOwner{OwnerType: &metal3v1alpha1.BareMetalHost{}})
 
 	if preprovImgEnable {
 		controller.Owns(&metal3v1alpha1.PreprovisioningImage{})

--- a/controllers/metal3.io/preprovisioningimage_controller.go
+++ b/controllers/metal3.io/preprovisioningimage_controller.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	metal3 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
@@ -353,6 +355,7 @@ func (r *PreprovisioningImageReconciler) CanStart() bool {
 func (r *PreprovisioningImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metal3.PreprovisioningImage{}).
-		Owns(&corev1.Secret{}).
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			&handler.EnqueueRequestForOwner{OwnerType: &metal3.PreprovisioningImage{}}).
 		Complete(r)
 }


### PR DESCRIPTION
The default meaning of the Owns() method in the controller-runtime controller is to only trigger reconciles on owner references where we have the 'controller' flag set.

We have never set the 'controller' flag on the networkData Secret used in both the BareMetalHost and PreprovisioningImage controllers.

Since 8550d61f4355f6537b1fc1cd8c480d2ff493e9e9 we no longer set the 'controller' flag on our owner references for Secrets either, in order to allow the same BMC Secret to be shared amongst multiple hosts.

In each of these case we were either never or no longer triggering a reconcile when the Secret changed. Use the equivalent Watch() method call without the IsController option set in the handler to ensure that we still trigger a reconcile even when the 'controller' flag is not set in the owner reference.