### PR TITLE
METAL-376: Re-enable RAID interfaces

### DIFF
--- a/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/idrac.go
+++ b/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/idrac.go
@@ -91,9 +91,7 @@ func (a *iDracAccessDetails) PowerInterface() string {
 }
 
 func (a *iDracAccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	//return "idrac-wsman"
-	return "no-raid"
+	return "idrac-wsman"
 }
 
 func (a *iDracAccessDetails) VendorInterface() string {

--- a/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/idrac_virtualmedia.go
+++ b/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/idrac_virtualmedia.go
@@ -85,9 +85,7 @@ func (a *redfishiDracVirtualMediaAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	// return "idrac-redfish"
-	return "no-raid"
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) VendorInterface() string {

--- a/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/ilo5.go
+++ b/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/ilo5.go
@@ -87,9 +87,7 @@ func (a *iLO5AccessDetails) PowerInterface() string {
 }
 
 func (a *iLO5AccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	//return "ilo5"
-	return "no-raid"
+	return "ilo5"
 }
 
 func (a *iLO5AccessDetails) VendorInterface() string {

--- a/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/redfish.go
+++ b/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/redfish.go
@@ -164,9 +164,7 @@ func (a *redfishiDracAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracAccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	// return "idrac-redfish"
-	return "no-raid"
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracAccessDetails) VendorInterface() string {

--- a/pkg/hardwareutils/bmc/idrac.go
+++ b/pkg/hardwareutils/bmc/idrac.go
@@ -91,9 +91,7 @@ func (a *iDracAccessDetails) PowerInterface() string {
 }
 
 func (a *iDracAccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	//return "idrac-wsman"
-	return "no-raid"
+	return "idrac-wsman"
 }
 
 func (a *iDracAccessDetails) VendorInterface() string {

--- a/pkg/hardwareutils/bmc/idrac_virtualmedia.go
+++ b/pkg/hardwareutils/bmc/idrac_virtualmedia.go
@@ -85,9 +85,7 @@ func (a *redfishiDracVirtualMediaAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	// return "idrac-redfish"
-	return "no-raid"
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) VendorInterface() string {

--- a/pkg/hardwareutils/bmc/ilo5.go
+++ b/pkg/hardwareutils/bmc/ilo5.go
@@ -87,9 +87,7 @@ func (a *iLO5AccessDetails) PowerInterface() string {
 }
 
 func (a *iLO5AccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	//return "ilo5"
-	return "no-raid"
+	return "ilo5"
 }
 
 func (a *iLO5AccessDetails) VendorInterface() string {

--- a/pkg/hardwareutils/bmc/redfish.go
+++ b/pkg/hardwareutils/bmc/redfish.go
@@ -164,9 +164,7 @@ func (a *redfishiDracAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracAccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	// return "idrac-redfish"
-	return "no-raid"
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracAccessDetails) VendorInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/idrac.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/idrac.go
@@ -91,9 +91,7 @@ func (a *iDracAccessDetails) PowerInterface() string {
 }
 
 func (a *iDracAccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	//return "idrac-wsman"
-	return "no-raid"
+	return "idrac-wsman"
 }
 
 func (a *iDracAccessDetails) VendorInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/idrac_virtualmedia.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/idrac_virtualmedia.go
@@ -85,9 +85,7 @@ func (a *redfishiDracVirtualMediaAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	// return "idrac-redfish"
-	return "no-raid"
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) VendorInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/ilo5.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/ilo5.go
@@ -87,9 +87,7 @@ func (a *iLO5AccessDetails) PowerInterface() string {
 }
 
 func (a *iLO5AccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	//return "ilo5"
-	return "no-raid"
+	return "ilo5"
 }
 
 func (a *iLO5AccessDetails) VendorInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/redfish.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/redfish.go
@@ -164,9 +164,7 @@ func (a *redfishiDracAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishiDracAccessDetails) RAIDInterface() string {
-	// Disabled RAID in OpenShift because we are not ready to support it
-	// return "idrac-redfish"
-	return "no-raid"
+	return "idrac-redfish"
 }
 
 func (a *redfishiDracAccessDetails) VendorInterface() string {


### PR DESCRIPTION
Re-enable RAID interfaces which were previously disabled only in OpenShift BMO (downstream), to be able to support RAID configuration using OpenShift BMO. 
This change reverts:
- https://github.com/openshift/baremetal-operator/commit/e2d5a7591c5abf751331a0e111e29f1b519c0e11
- https://github.com/openshift/baremetal-operator/commit/2b6f680e8c812a0016301e4dfb03fb9c9bdb58da