### PR TITLE
NO-ISSUE: Sync upstream April 29

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -44,3 +44,13 @@ jobs:
             "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
           }
         job_timeout: "1000"
+    - name: Slack Notification on Failure
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@4e5fb42d249be6a45a298f3c9543b111b02f7907 # 2.3.0
+      env:
+        SLACK_TITLE: 'GitHub Action Failed in ${{ github.repository }}'
+        SLACK_COLOR: '#FF0000'
+        SLACK_MESSAGE: 'The GitHub Action workflow failed for baremetal operator image build.'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_CHANNEL: metal3-github-actions-notify
+        SLACK_USERNAME: metal3-github-actions-notify

--- a/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go
+++ b/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go
@@ -56,10 +56,11 @@ type HostFirmwareComponentsSpec struct {
 type HostFirmwareComponentsStatus struct {
 	// Updates is the list of all firmware components that should be updated
 	// they are specified via name and url fields.
+	// +optional
 	Updates []FirmwareUpdate `json:"updates"`
 
 	// Components is the list of all available firmware components and their information.
-	Components []FirmwareComponentStatus `json:"components"`
+	Components []FirmwareComponentStatus `json:"components,omitempty"`
 
 	// Time that the status was last updated
 	// +optional

--- a/config/base/crds/bases/metal3.io_hostfirmwarecomponents.yaml
+++ b/config/base/crds/bases/metal3.io_hostfirmwarecomponents.yaml
@@ -170,9 +170,6 @@ spec:
                   - url
                   type: object
                 type: array
-            required:
-            - components
-            - updates
             type: object
         type: object
     served: true

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -1787,9 +1787,6 @@ spec:
                   - url
                   type: object
                 type: array
-            required:
-            - components
-            - updates
             type: object
         type: object
     served: true

--- a/controllers/metal3.io/hostfirmwarecomponents_controller.go
+++ b/controllers/metal3.io/hostfirmwarecomponents_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -151,23 +152,21 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, nil
 	}
 
-	newStatus, err := r.updateHostFirmware(info)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("could not update hostfirmwarecomponents: %w", err)
-	}
-
+	info.log.Info("retrieving firmware components and saving to resource", "Node", bmh.Status.Provisioning.ID)
 	// Check ironic for the components information if possible
 	components, err := prov.GetFirmwareComponents()
-	info.log.Info("retrieving firmware components and saving to resource", "Node", bmh.Status.Provisioning.ID)
 
 	if err != nil {
-		reqLogger.Error(err, "provisioner returns error", "RequeueAfter", provisionerRetryDelay)
-		setUpdatesCondition(info.hfc.GetGeneration(), &newStatus, info, metal3api.HostFirmwareComponentsValid, metav1.ConditionFalse, reasonInvalidComponent, err.Error())
+		if errors.Is(err, provisioner.ErrFirmwareUpdateUnsupported) {
+			return ctrl.Result{Requeue: false}, err
+		}
+		reqLogger.Info("provisioner returns error", "Error", err.Error(), "RequeueAfter", provisionerRetryDelay)
 		return ctrl.Result{Requeue: true, RequeueAfter: provisionerRetryDelay}, err
 	}
 
-	if err = r.updateHostFirmwareComponents(newStatus, components, info); err != nil {
-		return ctrl.Result{Requeue: false}, err
+	if err = r.updateHostFirmware(info, components); err != nil {
+		info.log.Info("updateHostFirmware returned error")
+		return ctrl.Result{}, fmt.Errorf("could not update hostfirmwarecomponents: %w", err)
 	}
 
 	for _, e := range info.events {
@@ -181,14 +180,19 @@ func (r *HostFirmwareComponentsReconciler) Reconcile(ctx context.Context, req ct
 }
 
 // Update the HostFirmwareComponents resource using the components from provisioner.
-func (r *HostFirmwareComponentsReconciler) updateHostFirmware(info *rhfcInfo) (newStatus metal3api.HostFirmwareComponentsStatus, err error) {
+func (r *HostFirmwareComponentsReconciler) updateHostFirmware(info *rhfcInfo, components []metal3api.FirmwareComponentStatus) (err error) {
 	dirty := false
-
+	var newStatus metal3api.HostFirmwareComponentsStatus
 	// change the Updates in Status
 	newStatus.Updates = info.hfc.Spec.Updates
+	// change the Components in Status
+	newStatus.Components = components
 
 	// Check if the updates in the Spec are different than Status
 	updatesMismatch := !reflect.DeepEqual(info.hfc.Status.Updates, info.hfc.Spec.Updates)
+	if len(info.hfc.Spec.Updates) == 0 && len(info.hfc.Status.Updates) == 0 {
+		updatesMismatch = false
+	}
 
 	reason := reasonValidComponent
 	generation := info.hfc.GetGeneration()
@@ -220,32 +224,6 @@ func (r *HostFirmwareComponentsReconciler) updateHostFirmware(info *rhfcInfo) (n
 	// Update Status if has changed
 	if dirty {
 		info.log.Info("Status for HostFirmwareComponents changed")
-		info.hfc.Status = *newStatus.DeepCopy()
-
-		t := metav1.Now()
-		info.hfc.Status.LastUpdated = &t
-		return newStatus, r.Status().Update(info.ctx, info.hfc)
-	}
-	return newStatus, nil
-}
-
-// Update the HostFirmwareComponents resource using the components from provisioner.
-func (r *HostFirmwareComponentsReconciler) updateHostFirmwareComponents(newStatus metal3api.HostFirmwareComponentsStatus, components []metal3api.FirmwareComponentStatus, info *rhfcInfo) (err error) {
-	dirty := false
-	// change the Components in Status
-	newStatus.Components = components
-	// Check if the components information we retrieved is different from the one in Status
-	componentsInfoMismatch := !reflect.DeepEqual(components, info.hfc.Status.Components)
-	reason := reasonValidComponent
-	generation := info.hfc.GetGeneration()
-	// Log the components we have
-	info.log.Info("firmware components for node", "components", components, "bmh", info.bmh.Name)
-	if componentsInfoMismatch {
-		setUpdatesCondition(generation, &newStatus, info, metal3api.HostFirmwareComponentsChangeDetected, metav1.ConditionTrue, reason, "")
-		dirty = true
-	}
-	if dirty {
-		info.log.Info("Components Status for HostFirmwareComponents changed")
 		info.hfc.Status = *newStatus.DeepCopy()
 
 		t := metav1.Now()

--- a/controllers/metal3.io/hostfirmwarecomponents_test.go
+++ b/controllers/metal3.io/hostfirmwarecomponents_test.go
@@ -425,12 +425,9 @@ func TestStoreHostFirmwareComponents(t *testing.T) {
 				bmh: bmh,
 			}
 
-			currentStatus, err := r.updateHostFirmware(info)
-			assert.NoError(t, err)
-
 			components, err := prov.GetFirmwareComponents()
 			assert.NoError(t, err)
-			err = r.updateHostFirmwareComponents(currentStatus, components, info)
+			err = r.updateHostFirmware(info, components)
 			assert.NoError(t, err)
 
 			// Check that resources get created or updated

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.21
 require (
 	github.com/go-logr/logr v1.4.1
 	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
-	github.com/gophercloud/gophercloud/v2 v2.0.0-beta.3.0.20240416104816-9aef3836d310
+	github.com/gophercloud/gophercloud/v2 v2.0.0-beta.4.0.20240422125343-8b1eebe1fa46
 	github.com/metal3-io/baremetal-operator/apis v0.5.1
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.5.1
-	github.com/onsi/gomega v1.32.0
+	github.com/onsi/gomega v1.33.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/google/safetext v0.0.0-20230106111101-7156a760e523 h1:i4NsbmB9pD5+Ggp
 github.com/google/safetext v0.0.0-20230106111101-7156a760e523/go.mod h1:mJNEy0r5YPHC7ChQffpOszlGB4L1iqjXWpIEKcFpr9s=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gophercloud/gophercloud/v2 v2.0.0-beta.3.0.20240416104816-9aef3836d310 h1:7pom2WwZIzl8hujnJriF9f2MLP9EmL8c36JbTBpOUDw=
-github.com/gophercloud/gophercloud/v2 v2.0.0-beta.3.0.20240416104816-9aef3836d310/go.mod h1:HbB8pJ/nycmlTRO++YTIFt9KUDx5c9gdaTFbk4oB5wA=
+github.com/gophercloud/gophercloud/v2 v2.0.0-beta.4.0.20240422125343-8b1eebe1fa46 h1:RCFJPDcv22rnyX38Te7xO4Nw45hshCtdA85AlFLoCZY=
+github.com/gophercloud/gophercloud/v2 v2.0.0-beta.4.0.20240422125343-8b1eebe1fa46/go.mod h1:HbB8pJ/nycmlTRO++YTIFt9KUDx5c9gdaTFbk4oB5wA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -77,10 +77,10 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
-github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
-github.com/onsi/gomega v1.32.0 h1:JRYU78fJ1LPxlckP6Txi/EYqJvjtMrDC04/MM5XRHPk=
-github.com/onsi/gomega v1.32.0/go.mod h1:a4x4gW6Pz2yK1MAmvluYme5lvYTn61afQ2ETw/8n4Lg=
+github.com/onsi/ginkgo/v2 v2.17.1 h1:V++EzdbhI4ZV4ev0UTIj0PzhzOcReJFyJaLjtSF55M8=
+github.com/onsi/ginkgo/v2 v2.17.1/go.mod h1:llBI3WDLL9Z6taip6f33H76YcWtJv+7R3HigUjbIBOs=
+github.com/onsi/gomega v1.33.0 h1:snPCflnZrpMsy94p4lXVEkHo12lmPnc3vY5XBbreexE=
+github.com/onsi/gomega v1.33.0/go.mod h1:+925n5YtiFsLzzafLUHzVMBpvvRAzrydIBiSIxjX3wY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -156,8 +156,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
-golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
+golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
+golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/provisioner/ironic/delete_test.go
+++ b/pkg/provisioner/ironic/delete_test.go
@@ -92,7 +92,7 @@ func deleteTest(t *testing.T, detach bool) {
 			hostName: "worker-0",
 			ironic:   testserver.NewIronic(t).NodeError(nodeUUID, http.StatusGatewayTimeout),
 
-			expectedError: "failed to find node by ID 33ce8659-7400-4c68-9535-d10766f07a58: Gateway Timeout.*",
+			expectedError: "failed to find node by ID 33ce8659-7400-4c68-9535-d10766f07a58: .*",
 		},
 		{
 			name:   "not-ironic-node",

--- a/pkg/provisioner/ironic/inspecthardware_test.go
+++ b/pkg/provisioner/ironic/inspecthardware_test.go
@@ -84,7 +84,7 @@ func TestInspectHardware(t *testing.T) {
 				ProvisionState: "manageable",
 			}).WithInventoryFailed(nodeUUID, http.StatusBadRequest),
 
-			expectedError: "failed to retrieve hardware introspection data: Bad request with: \\[GET http://127.0.0.1:.*/v1/nodes/33ce8659-7400-4c68-9535-d10766f07a58/inventory\\], error message: An error\\\n",
+			expectedError: "failed to retrieve hardware introspection data: .*: An error",
 		},
 		{
 			name: "introspection-status-retry-on-wait",

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -176,18 +176,18 @@ func (p *ironicProvisioner) getNode() (*nodes.Node, error) {
 	}
 
 	ironicNode, err := nodes.Get(p.ctx, p.client, p.nodeID).Extract()
-	switch err.(type) {
-	case nil:
+	if err == nil {
 		p.debugLog.Info("found existing node by ID")
 		return ironicNode, nil
-	case gophercloud.ErrDefault404:
+	}
+
+	if gophercloud.ResponseCodeIs(err, 404) {
 		// Look by ID failed, trying to lookup by hostname in case it was
 		// previously created
 		return nil, provisioner.ErrNeedsRegistration
-	default:
-		return nil, errors.Wrap(err,
-			fmt.Sprintf("failed to find node by ID %s", p.nodeID))
 	}
+
+	return nil, fmt.Errorf("failed to find node by ID %s: %w", p.nodeID, err)
 }
 
 // Verifies that node has port assigned by Ironic.
@@ -251,16 +251,15 @@ func (p *ironicProvisioner) findExistingHost(bootMACAddress string) (ironicNode 
 	for _, nodeName := range nodeSearchList {
 		p.debugLog.Info("looking for existing node by name", "name", nodeName)
 		ironicNode, err = nodes.Get(p.ctx, p.client, nodeName).Extract()
-		switch err.(type) {
-		case nil:
+		if err == nil {
 			p.debugLog.Info("found existing node by name", "name", nodeName, "node", ironicNode.UUID)
 			return ironicNode, nil
-		case gophercloud.ErrDefault404:
-			p.log.Info(
-				fmt.Sprintf("node with name %s doesn't exist", nodeName))
-		default:
-			return nil, errors.Wrap(err,
-				fmt.Sprintf("failed to find node by name %s", nodeName))
+		}
+
+		if gophercloud.ResponseCodeIs(err, 404) {
+			p.log.Info(fmt.Sprintf("node with name %s doesn't exist", nodeName))
+		} else {
+			return nil, fmt.Errorf("failed to find node by name %s: %w", nodeName, err)
 		}
 	}
 
@@ -276,8 +275,7 @@ func (p *ironicProvisioner) findExistingHost(bootMACAddress string) (ironicNode 
 	if len(allPorts) > 0 {
 		nodeUUID := allPorts[0].NodeUUID
 		ironicNode, err = nodes.Get(p.ctx, p.client, nodeUUID).Extract()
-		switch err.(type) {
-		case nil:
+		if err == nil {
 			p.debugLog.Info("found existing node by MAC", "MAC", bootMACAddress, "node", ironicNode.UUID, "name", ironicNode.Name)
 
 			// If the node has a name, this means we didn't find it above.
@@ -286,17 +284,14 @@ func (p *ironicProvisioner) findExistingHost(bootMACAddress string) (ironicNode 
 			}
 
 			return ironicNode, nil
-		case gophercloud.ErrDefault404:
-			return nil, errors.Wrap(err,
-				fmt.Sprintf("port %s exists but linked node doesn't %s", bootMACAddress, nodeUUID))
-		default:
-			return nil, errors.Wrap(err,
-				fmt.Sprintf("port %s exists but failed to find linked node by ID %s", bootMACAddress, nodeUUID))
 		}
-	} else {
-		p.log.Info("port with address doesn't exist", "MAC", bootMACAddress)
+		if gophercloud.ResponseCodeIs(err, 404) {
+			return nil, fmt.Errorf("port %s exists but linked node %s doesn't: %w", bootMACAddress, nodeUUID, err)
+		}
+		return nil, fmt.Errorf("port %s exists but failed to find linked node %s by ID: %w", bootMACAddress, nodeUUID, err)
 	}
 
+	p.log.Info("port with address doesn't exist", "MAC", bootMACAddress)
 	// Either the node was never created or the Ironic database has
 	// been dropped.
 	return nil, nil
@@ -415,14 +410,13 @@ func (p *ironicProvisioner) ValidateManagementAccess(data provisioner.Management
 		}
 
 		ironicNode, err = nodes.Create(p.ctx, p.client, nodeCreateOpts).Extract()
-		switch err.(type) {
-		case nil:
+		if err == nil {
 			p.publisher("Registered", "Registered new host")
-		case gophercloud.ErrDefault409:
+		} else if gophercloud.ResponseCodeIs(err, 409) {
 			p.log.Info("could not register host in ironic, busy")
 			result, err = retryAfterDelay(provisionRequeueDelay)
 			return
-		default:
+		} else {
 			result, err = transientError(errors.Wrap(err, "failed to register host in ironic"))
 			return
 		}
@@ -764,14 +758,13 @@ func (p *ironicProvisioner) tryUpdateNode(ironicNode *nodes.Node, updater *nodeU
 
 	p.log.Info("updating node settings in ironic", "updateCount", len(updater.Updates))
 	updatedNode, err = nodes.Update(p.ctx, p.client, ironicNode.UUID, updater.Updates).Extract()
-	switch err.(type) {
-	case nil:
+	if err == nil {
 		success = true
-	case gophercloud.ErrDefault409:
+	} else if gophercloud.ResponseCodeIs(err, 409) {
 		p.log.Info("could not update node settings in ironic, busy or update cannot be applied in the current state")
 		result, err = retryAfterDelay(provisionRequeueDelay)
-	default:
-		result, err = transientError(errors.Wrap(err, "failed to update host settings in ironic"))
+	} else {
+		result, err = transientError(fmt.Errorf("failed to update host settings in ironic: %w", err))
 	}
 
 	return
@@ -797,16 +790,14 @@ func (p *ironicProvisioner) tryChangeNodeProvisionState(ironicNode *nodes.Node, 
 	}
 
 	changeResult := nodes.ChangeProvisionState(p.ctx, p.client, ironicNode.UUID, opts)
-	switch changeResult.Err.(type) {
-	case nil:
+	if changeResult.Err == nil {
 		success = true
-	case gophercloud.ErrDefault409:
+	} else if gophercloud.ResponseCodeIs(changeResult.Err, 409) {
 		p.log.Info("could not change state of host, busy")
 		result, err = retryAfterDelay(provisionRequeueDelay)
 		return
-	default:
-		result, err = transientError(errors.Wrap(changeResult.Err,
-			fmt.Sprintf("failed to change provisioning state to %q", opts.Target)))
+	} else {
+		result, err = transientError(fmt.Errorf("failed to change provisioning state to %q: %w", opts.Target, changeResult.Err))
 		return
 	}
 
@@ -916,12 +907,12 @@ func (p *ironicProvisioner) InspectHardware(data provisioner.InspectData, restar
 	response := nodes.GetInventory(p.ctx, p.client, ironicNode.UUID)
 	introData, err := response.Extract()
 	if err != nil {
-		if _, isNotFound := err.(gophercloud.ErrDefault404); isNotFound {
+		if gophercloud.ResponseCodeIs(err, 404) {
 			// The node has just been enrolled, inspection hasn't been started yet.
 			result, started, err = p.startInspection(data, ironicNode)
 			return
 		}
-		result, err = transientError(errors.Wrap(err, "failed to retrieve hardware introspection data"))
+		result, err = transientError(fmt.Errorf("failed to retrieve hardware introspection data: %w", err))
 		return
 	}
 
@@ -1162,20 +1153,19 @@ func (p *ironicProvisioner) GetFirmwareComponents() ([]metal3api.FirmwareCompone
 	if !p.availableFeatures.HasFirmwareUpdates() {
 		return nil, fmt.Errorf("current ironic version does not support firmware updates")
 	}
-	// Get the components from Ironic via Gophercloud
-	componentList, componentListErr := nodes.ListFirmware(p.ctx, p.client, ironicNode.UUID).Extract()
-
-	if componentListErr != nil || len(componentList) == 0 {
-		bmcAccess, _ := p.bmcAccess()
-		if ironicNode.FirmwareInterface == "no-firmware" {
-			return nil, fmt.Errorf("driver %s does not support firmware updates", bmcAccess.Driver())
-		}
-
-		return nil, fmt.Errorf("could not get firmware components for node %s: %w", ironicNode.UUID, componentListErr)
-	}
 
 	// Setting to 2 since we only support bmc and bios
 	componentsInfo := make([]metal3api.FirmwareComponentStatus, 0, 2)
+
+	if ironicNode.FirmwareInterface == "no-firmware" {
+		return componentsInfo, provisioner.ErrFirmwareUpdateUnsupported
+	}
+	// Get the components from Ironic via Gophercloud
+	componentList, componentListErr := nodes.ListFirmware(p.ctx, p.client, ironicNode.UUID).Extract()
+
+	if componentListErr != nil {
+		return nil, fmt.Errorf("could not get firmware components for node %s: %w", ironicNode.UUID, componentListErr)
+	}
 
 	// Iterate over the list of components to extract their information and update the list.
 	for _, fwc := range componentList {
@@ -1188,9 +1178,12 @@ func (p *ironicProvisioner) GetFirmwareComponents() ([]metal3api.FirmwareCompone
 			InitialVersion:     fwc.InitialVersion,
 			CurrentVersion:     fwc.CurrentVersion,
 			LastVersionFlashed: fwc.LastVersionFlashed,
-			UpdatedAt: metav1.Time{
+		}
+		// Check if UpdatedAt is nil before adding it.
+		if fwc.UpdatedAt != nil {
+			component.UpdatedAt = metav1.Time{
 				Time: *fwc.UpdatedAt,
-			},
+			}
 		}
 		componentsInfo = append(componentsInfo, component)
 		p.log.Info("firmware component added for node", "component", fwc.Component, "node", ironicNode.UUID)
@@ -1242,13 +1235,11 @@ func (p *ironicProvisioner) setUpForProvisioning(ironicNode *nodes.Node, data pr
 	p.log.Info("validating host settings")
 
 	errorMessage, err := p.validateNode(ironicNode)
-	switch err.(type) {
-	case nil:
-	case gophercloud.ErrDefault409:
+	if gophercloud.ResponseCodeIs(err, 409) {
 		p.log.Info("could not validate host during registration, busy")
 		return retryAfterDelay(provisionRequeueDelay)
-	default:
-		return transientError(errors.Wrap(err, "failed to validate host during registration"))
+	} else if err != nil {
+		return transientError(fmt.Errorf("failed to validate host during registration: %w", err))
 	}
 	if errorMessage != "" {
 		return operationFailed(errorMessage)
@@ -1779,13 +1770,12 @@ func (p *ironicProvisioner) setMaintenanceFlag(ironicNode *nodes.Node, value boo
 		err = nodes.UnsetMaintenance(p.ctx, p.client, ironicNode.UUID).ExtractErr()
 	}
 
-	switch err.(type) {
-	case nil:
+	if err == nil {
 		result, err = operationContinuing(0)
-	case gophercloud.ErrDefault409:
+	} else if gophercloud.ResponseCodeIs(err, 409) {
 		p.log.Info("could not update maintenance in ironic, busy")
 		result, err = retryAfterDelay(provisionRequeueDelay)
-	default:
+	} else {
 		err = fmt.Errorf("failed to set host maintenance flag to %v (%w)", value, err)
 		result, err = transientError(err)
 	}
@@ -1944,16 +1934,15 @@ func (p *ironicProvisioner) Delete() (result provisioner.Result, err error) {
 
 	p.log.Info("host ready to be removed")
 	err = nodes.Delete(p.ctx, p.client, ironicNode.UUID).ExtractErr()
-	switch err.(type) {
-	case nil:
+	if err == nil {
 		p.log.Info("removed")
-	case gophercloud.ErrDefault409:
+	} else if gophercloud.ResponseCodeIs(err, 409) {
 		p.log.Info("could not remove host, busy")
 		return retryAfterDelay(provisionRequeueDelay)
-	case gophercloud.ErrDefault404:
+	} else if gophercloud.ResponseCodeIs(err, 404) {
 		p.log.Info("did not find host to delete, OK")
-	default:
-		return transientError(errors.Wrap(err, "failed to remove host"))
+	} else {
+		return transientError(fmt.Errorf("failed to remove host: %w", err))
 	}
 
 	return operationContinuing(0)
@@ -2007,8 +1996,7 @@ func (p *ironicProvisioner) changePower(ironicNode *nodes.Node, target nodes.Tar
 		ironicNode.UUID,
 		powerStateOpts)
 
-	switch changeResult.Err.(type) {
-	case nil:
+	if changeResult.Err == nil {
 		p.log.Info("power change OK")
 		event := map[nodes.TargetPowerState]struct{ Event, Reason string }{
 			nodes.PowerOn:      {Event: "PowerOn", Reason: "Host powered on"},
@@ -2017,18 +2005,17 @@ func (p *ironicProvisioner) changePower(ironicNode *nodes.Node, target nodes.Tar
 		}[target]
 		p.publisher(event.Event, event.Reason)
 		return operationContinuing(0)
-	case gophercloud.ErrDefault409:
+	} else if gophercloud.ResponseCodeIs(changeResult.Err, 409) {
 		p.log.Info("host is locked, trying again after delay", "delay", powerRequeueDelay)
 		return retryAfterDelay(powerRequeueDelay)
-	case gophercloud.ErrDefault400:
+	} else if gophercloud.ResponseCodeIs(changeResult.Err, 400) {
 		// Error 400 Bad Request means target power state is not supported by vendor driver
 		if target == nodes.SoftPowerOff {
 			changeResult.Err = softPowerOffUnsupportedError{changeResult.Err}
 		}
 	}
 	p.log.Info("power change error", "message", changeResult.Err)
-	return transientError(errors.Wrap(changeResult.Err,
-		fmt.Sprintf("failed to %s node", target)))
+	return transientError(fmt.Errorf("failed to %s node: %w", target, changeResult.Err))
 }
 
 // PowerOn ensures the server is powered on independently of any image

--- a/pkg/provisioner/ironic/power_test.go
+++ b/pkg/provisioner/ironic/power_test.go
@@ -322,5 +322,5 @@ func TestSoftPowerOffFallback(t *testing.T) {
 
 	_, err = prov.changePower(&node, nodes.SoftPowerOff)
 	assert.Error(t, err)
-	assert.True(t, errors.As(err, &softPowerOffUnsupportedError{}))
+	assert.ErrorAs(t, err, &softPowerOffUnsupportedError{})
 }

--- a/pkg/provisioner/ironic/updatehardwarestate_test.go
+++ b/pkg/provisioner/ironic/updatehardwarestate_test.go
@@ -80,7 +80,7 @@ func TestUpdateHardwareState(t *testing.T) {
 			hostName: "worker-0",
 			ironic:   testserver.NewIronic(t).NodeError(nodeUUID, http.StatusGatewayTimeout),
 
-			expectedError: "failed to find node by ID 33ce8659-7400-4c68-9535-d10766f07a58: Gateway Timeout.*",
+			expectedError: "failed to find node by ID 33ce8659-7400-4c68-9535-d10766f07a58:.*",
 
 			expectUnreadablePower: true,
 		},

--- a/pkg/provisioner/ironic/validatemanagementaccess_test.go
+++ b/pkg/provisioner/ironic/validatemanagementaccess_test.go
@@ -1,7 +1,6 @@
 package ironic
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -737,9 +736,8 @@ func TestValidateManagementAccessExistingPortWithWrongUUID(t *testing.T) {
 	}
 
 	_, _, err = prov.ValidateManagementAccess(provisioner.ManagementAccessData{}, false, false)
-	endpoint := ironic.MockServer.Endpoint()
-	expected := fmt.Sprintf("failed to find existing host: port 11:11:11:11:11:11 exists but linked node doesn't random-wrong-id: Resource not found: [GET %snodes/random-wrong-id], error message: ", endpoint)
-	assert.EqualError(t, err, expected)
+	expected := "failed to find existing host: port 11:11:11:11:11:11 exists but linked node random-wrong-id doesn't:"
+	assert.ErrorContains(t, err, expected)
 }
 
 func TestValidateManagementAccessExistingPortButHasName(t *testing.T) {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -240,3 +240,6 @@ var ErrNeedsRegistration = errors.New("host not registered")
 // ErrNeedsPreprovisioningImage is returned if a preprovisioning image is
 // required.
 var ErrNeedsPreprovisioningImage = errors.New("no suitable Preprovisioning image available")
+
+// ErrFirmwareUpdateUnsupported is returned if the host can't execute firmware updates.
+var ErrFirmwareUpdateUnsupported = errors.New("host does not support Firmware Updates")

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes/requests.go
@@ -28,11 +28,13 @@ const (
 	Deploying    ProvisionState = "deploying"
 	DeployFail   ProvisionState = "deploy failed"
 	DeployDone   ProvisionState = "deploy complete"
+	DeployHold   ProvisionState = "deploy hold"
 	Deleting     ProvisionState = "deleting"
 	Deleted      ProvisionState = "deleted"
 	Cleaning     ProvisionState = "cleaning"
 	CleanWait    ProvisionState = "clean wait"
 	CleanFail    ProvisionState = "clean failed"
+	CleanHold    ProvisionState = "clean hold"
 	Error        ProvisionState = "error"
 	Rebuild      ProvisionState = "rebuild"
 	Inspecting   ProvisionState = "inspecting"
@@ -46,6 +48,10 @@ const (
 	UnrescueFail ProvisionState = "unrescue failed"
 	RescueWait   ProvisionState = "rescue wait"
 	Unrescuing   ProvisionState = "unrescuing"
+	Servicing    ProvisionState = "servicing"
+	ServiceWait  ProvisionState = "service wait"
+	ServiceFail  ProvisionState = "service fail"
+	ServiceHold  ProvisionState = "service hold"
 )
 
 // TargetProvisionState is used when setting the provision state for a node.
@@ -63,6 +69,16 @@ const (
 	TargetRescue   TargetProvisionState = "rescue"
 	TargetUnrescue TargetProvisionState = "unrescue"
 	TargetRebuild  TargetProvisionState = "rebuild"
+	TargetService  TargetProvisionState = "service"
+	TargetUnhold   TargetProvisionState = "unhold"
+)
+
+const (
+	StepHold     string = "hold"
+	StepWait     string = "wait"
+	StepPowerOn  string = "power_on"
+	StepPowerOff string = "power_off"
+	StepReboot   string = "reboot"
 )
 
 // ListOpts allows the filtering and sorting of paginated collections through
@@ -430,6 +446,9 @@ type CleanStep struct {
 	Args      map[string]interface{} `json:"args,omitempty"`
 }
 
+// A service step looks the same as a cleaning step.
+type ServiceStep = CleanStep
+
 // A deploy step has required keys ‘interface’, ‘step’, ’args’ and ’priority’.
 // The value for ‘args’ is a keyword variable argument dictionary that is passed to the deploy step
 // method. Priority is a numeric priority at which the step is running.
@@ -461,6 +480,7 @@ type ProvisionStateOpts struct {
 	ConfigDrive    interface{}          `json:"configdrive,omitempty"`
 	CleanSteps     []CleanStep          `json:"clean_steps,omitempty"`
 	DeploySteps    []DeployStep         `json:"deploy_steps,omitempty"`
+	ServiceSteps   []ServiceStep        `json:"service_steps,omitempty"`
 	RescuePassword string               `json:"rescue_password,omitempty"`
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes/results.go
@@ -183,6 +183,9 @@ type Node struct {
 	// Current deploy step.
 	DeployStep map[string]interface{} `json:"deploy_step"`
 
+	// Current service step.
+	ServiceStep map[string]interface{} `json:"service_step"`
+
 	// String which can be used by external schedulers to identify this Node as a unit of a specific type of resource.
 	// For more details, see: https://docs.openstack.org/ironic/latest/install/configure-nova-flavors.html
 	ResourceClass string `json:"resource_class"`

--- a/vendor/github.com/gophercloud/gophercloud/v2/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/v2/provider_client.go
@@ -327,9 +327,6 @@ type RequestOpts struct {
 	// OmitHeaders specifies the HTTP headers which should be omitted.
 	// OmitHeaders will override MoreHeaders
 	OmitHeaders []string
-	// ErrorContext specifies the resource error type to return if an error is encountered.
-	// This lets resources override default error messages based on the response status code.
-	ErrorContext error
 	// KeepResponseBody specifies whether to keep the HTTP response body. Usually used, when the HTTP
 	// response body is considered for further use. Valid when JSONResponse is nil.
 	KeepResponseBody bool
@@ -461,13 +458,7 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 			ResponseHeader: resp.Header,
 		}
 
-		errType := options.ErrorContext
 		switch resp.StatusCode {
-		case http.StatusBadRequest:
-			err = ErrDefault400{respErr}
-			if error400er, ok := errType.(Err400er); ok {
-				err = error400er.Error400(respErr)
-			}
 		case http.StatusUnauthorized:
 			if client.ReauthFunc != nil && !state.hasReauthenticated {
 				err = client.Reauthenticate(ctx, prereqtok)
@@ -498,41 +489,7 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 				}
 				return resp, nil
 			}
-			err = ErrDefault401{respErr}
-			if error401er, ok := errType.(Err401er); ok {
-				err = error401er.Error401(respErr)
-			}
-		case http.StatusForbidden:
-			err = ErrDefault403{respErr}
-			if error403er, ok := errType.(Err403er); ok {
-				err = error403er.Error403(respErr)
-			}
-		case http.StatusNotFound:
-			err = ErrDefault404{respErr}
-			if error404er, ok := errType.(Err404er); ok {
-				err = error404er.Error404(respErr)
-			}
-		case http.StatusMethodNotAllowed:
-			err = ErrDefault405{respErr}
-			if error405er, ok := errType.(Err405er); ok {
-				err = error405er.Error405(respErr)
-			}
-		case http.StatusRequestTimeout:
-			err = ErrDefault408{respErr}
-			if error408er, ok := errType.(Err408er); ok {
-				err = error408er.Error408(respErr)
-			}
-		case http.StatusConflict:
-			err = ErrDefault409{respErr}
-			if error409er, ok := errType.(Err409er); ok {
-				err = error409er.Error409(respErr)
-			}
 		case http.StatusTooManyRequests, 498:
-			err = ErrDefault429{respErr}
-			if error429er, ok := errType.(Err429er); ok {
-				err = error429er.Error429(respErr)
-			}
-
 			maxTries := client.MaxBackoffRetries
 			if maxTries == 0 {
 				maxTries = DefaultMaxBackoffRetries
@@ -549,26 +506,6 @@ func (client *ProviderClient) doRequest(ctx context.Context, method, url string,
 				}
 
 				return client.doRequest(ctx, method, url, options, state)
-			}
-		case http.StatusInternalServerError:
-			err = ErrDefault500{respErr}
-			if error500er, ok := errType.(Err500er); ok {
-				err = error500er.Error500(respErr)
-			}
-		case http.StatusBadGateway:
-			err = ErrDefault502{respErr}
-			if error502er, ok := errType.(Err502er); ok {
-				err = error502er.Error502(respErr)
-			}
-		case http.StatusServiceUnavailable:
-			err = ErrDefault503{respErr}
-			if error503er, ok := errType.(Err503er); ok {
-				err = error503er.Error503(respErr)
-			}
-		case http.StatusGatewayTimeout:
-			err = ErrDefault504{respErr}
-			if error504er, ok := errType.(Err504er); ok {
-				err = error504er.Error504(respErr)
 			}
 		}
 

--- a/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go
@@ -56,10 +56,11 @@ type HostFirmwareComponentsSpec struct {
 type HostFirmwareComponentsStatus struct {
 	// Updates is the list of all firmware components that should be updated
 	// they are specified via name and url fields.
+	// +optional
 	Updates []FirmwareUpdate `json:"updates"`
 
 	// Components is the list of all available firmware components and their information.
-	Components []FirmwareComponentStatus `json:"components"`
+	Components []FirmwareComponentStatus `json:"components,omitempty"`
 
 	// Time that the status was last updated
 	// +optional

--- a/vendor/github.com/onsi/gomega/CHANGELOG.md
+++ b/vendor/github.com/onsi/gomega/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.33.0
+
+### Features
+
+`Receive` not accepts `Receive(<POINTER>, MATCHER>)`, allowing you to pick out a specific value on the channel that satisfies the provided matcher and is stored in the provided pointer.
+
+### Maintenance
+- Bump github.com/onsi/ginkgo/v2 from 2.15.0 to 2.17.1 (#745) [9999deb]
+- Bump github-pages from 229 to 230 in /docs (#735) [cb5ff21]
+- Bump golang.org/x/net from 0.20.0 to 0.23.0 (#746) [bac6596]
+
 ## 1.32.0
 
 ### Maintenance

--- a/vendor/github.com/onsi/gomega/gomega_dsl.go
+++ b/vendor/github.com/onsi/gomega/gomega_dsl.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
-const GOMEGA_VERSION = "1.32.0"
+const GOMEGA_VERSION = "1.33.0"
 
 const nilGomegaPanic = `You are trying to make an assertion, but haven't registered Gomega's fail handler.
 If you're using Ginkgo then you probably forgot to put your assertion in an It().

--- a/vendor/github.com/onsi/gomega/matchers.go
+++ b/vendor/github.com/onsi/gomega/matchers.go
@@ -194,20 +194,21 @@ func BeClosed() types.GomegaMatcher {
 //
 // will repeatedly attempt to pull values out of `c` until a value matching "bar" is received.
 //
-// Finally, if you want to have a reference to the value *sent* to the channel you can pass the `Receive` matcher a pointer to a variable of the appropriate type:
+// Furthermore, if you want to have a reference to the value *sent* to the channel you can pass the `Receive` matcher a pointer to a variable of the appropriate type:
 //
 //	var myThing thing
 //	Eventually(thingChan).Should(Receive(&myThing))
 //	Expect(myThing.Sprocket).Should(Equal("foo"))
 //	Expect(myThing.IsValid()).Should(BeTrue())
+//
+// Finally, if you want to match the received object as well as get the actual received value into a variable, so you can reason further about the value received,
+// you can pass a pointer to a variable of the approriate type first, and second a matcher:
+//
+//	var myThing thing
+//	Eventually(thingChan).Should(Receive(&myThing, ContainSubstring("bar")))
 func Receive(args ...interface{}) types.GomegaMatcher {
-	var arg interface{}
-	if len(args) > 0 {
-		arg = args[0]
-	}
-
 	return &matchers.ReceiveMatcher{
-		Arg: arg,
+		Args: args,
 	}
 }
 

--- a/vendor/github.com/onsi/gomega/matchers/receive_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/receive_matcher.go
@@ -3,6 +3,7 @@
 package matchers
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -10,7 +11,7 @@ import (
 )
 
 type ReceiveMatcher struct {
-	Arg           interface{}
+	Args          []interface{}
 	receivedValue reflect.Value
 	channelClosed bool
 }
@@ -29,15 +30,38 @@ func (matcher *ReceiveMatcher) Match(actual interface{}) (success bool, err erro
 
 	var subMatcher omegaMatcher
 	var hasSubMatcher bool
+	var resultReference interface{}
 
-	if matcher.Arg != nil {
-		subMatcher, hasSubMatcher = (matcher.Arg).(omegaMatcher)
-		if !hasSubMatcher {
-			argType := reflect.TypeOf(matcher.Arg)
-			if argType.Kind() != reflect.Ptr {
-				return false, fmt.Errorf("Cannot assign a value from the channel:\n%s\nTo:\n%s\nYou need to pass a pointer!", format.Object(actual, 1), format.Object(matcher.Arg, 1))
-			}
+	// Valid arg formats are as follows, always with optional POINTER before
+	// optional MATCHER:
+	//   - Receive()
+	//   - Receive(POINTER)
+	//   - Receive(MATCHER)
+	//   - Receive(POINTER, MATCHER)
+	args := matcher.Args
+	if len(args) > 0 {
+		arg := args[0]
+		_, isSubMatcher := arg.(omegaMatcher)
+		if !isSubMatcher && reflect.ValueOf(arg).Kind() == reflect.Ptr {
+			// Consume optional POINTER arg first, if it ain't no matcher ;)
+			resultReference = arg
+			args = args[1:]
 		}
+	}
+	if len(args) > 0 {
+		arg := args[0]
+		subMatcher, hasSubMatcher = arg.(omegaMatcher)
+		if !hasSubMatcher {
+			// At this point we assume the dev user wanted to assign a received
+			// value, so [POINTER,]MATCHER.
+			return false, fmt.Errorf("Cannot assign a value from the channel:\n%s\nTo:\n%s\nYou need to pass a pointer!", format.Object(actual, 1), format.Object(arg, 1))
+		}
+		// Consume optional MATCHER arg.
+		args = args[1:]
+	}
+	if len(args) > 0 {
+		// If there are still args present, reject all.
+		return false, errors.New("Receive matcher expects at most an optional pointer and/or an optional matcher")
 	}
 
 	winnerIndex, value, open := reflect.Select([]reflect.SelectCase{
@@ -58,16 +82,20 @@ func (matcher *ReceiveMatcher) Match(actual interface{}) (success bool, err erro
 	}
 
 	if hasSubMatcher {
-		if didReceive {
-			matcher.receivedValue = value
-			return subMatcher.Match(matcher.receivedValue.Interface())
+		if !didReceive {
+			return false, nil
 		}
-		return false, nil
+		matcher.receivedValue = value
+		if match, err := subMatcher.Match(matcher.receivedValue.Interface()); err != nil || !match {
+			return match, err
+		}
+		// if we received a match, then fall through in order to handle an
+		// optional assignment of the received value to the specified reference.
 	}
 
 	if didReceive {
-		if matcher.Arg != nil {
-			outValue := reflect.ValueOf(matcher.Arg)
+		if resultReference != nil {
+			outValue := reflect.ValueOf(resultReference)
 
 			if value.Type().AssignableTo(outValue.Elem().Type()) {
 				outValue.Elem().Set(value)
@@ -77,7 +105,7 @@ func (matcher *ReceiveMatcher) Match(actual interface{}) (success bool, err erro
 				outValue.Elem().Set(value.Elem())
 				return true, nil
 			} else {
-				return false, fmt.Errorf("Cannot assign a value from the channel:\n%s\nType:\n%s\nTo:\n%s", format.Object(actual, 1), format.Object(value.Interface(), 1), format.Object(matcher.Arg, 1))
+				return false, fmt.Errorf("Cannot assign a value from the channel:\n%s\nType:\n%s\nTo:\n%s", format.Object(actual, 1), format.Object(value.Interface(), 1), format.Object(resultReference, 1))
 			}
 
 		}
@@ -88,7 +116,11 @@ func (matcher *ReceiveMatcher) Match(actual interface{}) (success bool, err erro
 }
 
 func (matcher *ReceiveMatcher) FailureMessage(actual interface{}) (message string) {
-	subMatcher, hasSubMatcher := (matcher.Arg).(omegaMatcher)
+	var matcherArg interface{}
+	if len(matcher.Args) > 0 {
+		matcherArg = matcher.Args[len(matcher.Args)-1]
+	}
+	subMatcher, hasSubMatcher := (matcherArg).(omegaMatcher)
 
 	closedAddendum := ""
 	if matcher.channelClosed {
@@ -105,7 +137,11 @@ func (matcher *ReceiveMatcher) FailureMessage(actual interface{}) (message strin
 }
 
 func (matcher *ReceiveMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	subMatcher, hasSubMatcher := (matcher.Arg).(omegaMatcher)
+	var matcherArg interface{}
+	if len(matcher.Args) > 0 {
+		matcherArg = matcher.Args[len(matcher.Args)-1]
+	}
+	subMatcher, hasSubMatcher := (matcherArg).(omegaMatcher)
 
 	closedAddendum := ""
 	if matcher.channelClosed {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -77,7 +77,7 @@ github.com/google/safetext/yamltemplate
 # github.com/google/uuid v1.6.0
 ## explicit
 github.com/google/uuid
-# github.com/gophercloud/gophercloud/v2 v2.0.0-beta.3.0.20240416104816-9aef3836d310
+# github.com/gophercloud/gophercloud/v2 v2.0.0-beta.4.0.20240422125343-8b1eebe1fa46
 ## explicit; go 1.21
 github.com/gophercloud/gophercloud/v2
 github.com/gophercloud/gophercloud/v2/openstack/baremetal/httpbasic
@@ -122,7 +122,7 @@ github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/onsi/gomega v1.32.0
+# github.com/onsi/gomega v1.33.0
 ## explicit; go 1.20
 github.com/onsi/gomega
 github.com/onsi/gomega/format


### PR DESCRIPTION
$ git fetch upstream
$ git fetch downstream
$ git checkout -b new-sync-downstream dowstream/master
$ git merge upstream/main
```
[iurygregory@blacklotus baremetal-operator]$ git merge upstream/main 
Auto-merging config/render/capm3.yaml
Merge made by the 'ort' strategy.
 .github/workflows/build-images-action.yml                    |  10 ++++++
 apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go      |   3 +-
 config/base/crds/bases/metal3.io_hostfirmwarecomponents.yaml |   3 --
 config/render/capm3.yaml                                     |   3 --
 controllers/metal3.io/hostfirmwarecomponents_controller.go   |  54 ++++++++++---------------------
 controllers/metal3.io/hostfirmwarecomponents_test.go         |   5 +--
 go.mod                                                       |   4 +--
 go.sum                                                       |  16 +++++-----
 pkg/provisioner/ironic/delete_test.go                        |   2 +-
 pkg/provisioner/ironic/inspecthardware_test.go               |   2 +-
 pkg/provisioner/ironic/ironic.go                             | 133 +++++++++++++++++++++++++++++++++++------------------------------------------
 pkg/provisioner/ironic/power_test.go                         |   2 +-
 pkg/provisioner/ironic/updatehardwarestate_test.go           |   2 +-
 pkg/provisioner/ironic/validatemanagementaccess_test.go      |   6 ++--
 pkg/provisioner/provisioner.go                               |   3 ++
 15 files changed, 108 insertions(+), 140 deletions(-)
 ```
 
 $ go mod vendor
 ```
modified:   vendor/github.com/gophercloud/gophercloud/v2/errors.go
modified:   vendor/github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes/requests.go
modified:   vendor/github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes/results.go
modified:   vendor/github.com/gophercloud/gophercloud/v2/provider_client.go
modified:   vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/hostfirmwarecomponents_types.go
modified:   vendor/github.com/onsi/gomega/CHANGELOG.md
modified:   vendor/github.com/onsi/gomega/gomega_dsl.go
modified:   vendor/github.com/onsi/gomega/matchers.go
modified:   vendor/github.com/onsi/gomega/matchers/receive_matcher.go
modified:   vendor/modules.txt
```