### PR TITLE
OCPBUGS-33048: PreprovisioningImage should not be created on poweroff

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -786,7 +786,7 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 		return actionError{err}
 	}
 	switch info.host.Status.Provisioning.State {
-	case metal3api.StateRegistering, metal3api.StateExternallyProvisioned, metal3api.StateDeleting:
+	case metal3api.StateRegistering, metal3api.StateExternallyProvisioned, metal3api.StateDeleting, metal3api.StatePoweringOffBeforeDelete:
 		// No need to create PreprovisioningImage if host is not yet registered
 		// or is externally provisioned
 		preprovImgFormats = nil


### PR DESCRIPTION
PreprovisioningImage not created on poweroff

There is a new state StatePoweringOffBeforeDelete
that should not create the PreprovisioningImage.

This new state comes from a previous one called
StateDeleting that was contemplated about
not creating the PreprovisioningImage.

Just added the new state to nor create the image