### PR TITLE
OCPBUGS-36285: Mount ironic credentials as volumes

### DIFF
--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -180,9 +180,10 @@ for overlay in "${IRONIC_OVERLAYS[@]}"; do
     "${overlay}/ironic-htpasswd"
   envsubst < "${REPO_ROOT}/ironic-deployment/components/basic-auth/ironic-auth-config-tpl" > \
   "${overlay}/ironic-auth-config"
+
   if [[ "${overlay}" =~ -with-inspector ]]; then
     IRONIC_INSPECTOR_AUTH_CONFIG_TPL="/tmp/ironic-inspector-auth-config-tpl"
-    curl -o "${IRONIC_INSPECTOR_AUTH_CONFIG_TPL}" https://raw.githubusercontent.com/metal3-io/baremetal-operator/release-0.5/ironic-deployment/components/basic-auth/ironic-inspector-auth-config-tpl 
+    curl -o "${IRONIC_INSPECTOR_AUTH_CONFIG_TPL}" https://raw.githubusercontent.com/metal3-io/baremetal-operator/release-0.5/ironic-deployment/components/basic-auth/ironic-inspector-auth-config-tpl
     envsubst < "${IRONIC_INSPECTOR_AUTH_CONFIG_TPL}" > \
       "${overlay}/ironic-inspector-auth-config"
     echo "INSPECTOR_HTPASSWD=$(htpasswd -n -b -B "${IRONIC_INSPECTOR_USERNAME}" \

--- a/ironic-deployment/components/basic-auth/auth.yaml
+++ b/ironic-deployment/components/basic-auth/auth.yaml
@@ -8,8 +8,13 @@ spec:
       containers:
       - name: ironic
         envFrom:
-        # This is the htpassword matching the ironic password
-        - secretRef:
-            name: ironic-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
+        volumeMounts:
+        - name: ironic-htpasswd
+          mountPath: "/auth/ironic"
+          readOnly: true
+      volumes:
+      - name: ironic-htpasswd
+        secret:
+          secretName: ironic-htpasswd

--- a/ironic-deployment/overlays/basic-auth_tls/basic-auth_tls.yaml
+++ b/ironic-deployment/overlays/basic-auth_tls/basic-auth_tls.yaml
@@ -8,7 +8,13 @@ spec:
       containers:
       - name: ironic-httpd
         envFrom:
-        - secretRef:
-            name: ironic-htpasswd
         - configMapRef:
             name: ironic-bmo-configmap
+        volumeMounts:
+        - name: ironic-htpasswd
+          mountPath: "/auth/ironic"
+          readOnly: true
+      volumes:
+      - name: ironic-htpasswd
+        secret:
+          secretName: ironic-htpasswd

--- a/ironic-deployment/overlays/basic-auth_tls/kustomization.yaml
+++ b/ironic-deployment/overlays/basic-auth_tls/kustomization.yaml
@@ -24,6 +24,7 @@ patches:
 # Example for how to generate the necessary secrets:
 # secretGenerator:
 # - behavior: create
-#   envs:
-#   - ironic-htpasswd
+#   files:
+#   - htpasswd=ironic-htpasswd
 #   name: ironic-htpasswd
+#   type: Opaque

--- a/ironic-deployment/overlays/e2e-release-24.0-with-inspector/kustomization.yaml
+++ b/ironic-deployment/overlays/e2e-release-24.0-with-inspector/kustomization.yaml
@@ -26,12 +26,12 @@ images:
 secretGenerator:
 - name: ironic-htpasswd
   behavior: create
-  envs:
-  - ironic-htpasswd
+  files:
+  - htpasswd=ironic-htpasswd
 - name: ironic-inspector-htpasswd
   behavior: create
-  envs:
-  - ironic-inspector-htpasswd
+  files:
+  - htpasswd=ironic-inspector-htpasswd
 - name: ironic-auth-config
   files:
   - auth-config=ironic-auth-config

--- a/ironic-deployment/overlays/e2e/kustomization.yaml
+++ b/ironic-deployment/overlays/e2e/kustomization.yaml
@@ -22,8 +22,9 @@ patches:
 secretGenerator:
 - name: ironic-htpasswd
   behavior: create
-  envs:
-  - ironic-htpasswd
+  files:
+  - htpasswd=ironic-htpasswd
+  type: Opaque
 
 replacements:
   # Replace IRONIC_HOST_IP in certificates with the PROVISIONING_IP from the configmap

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -164,7 +164,7 @@ if [[ "${DEPLOY_IRONIC}" == "true" ]]; then
     --namespace=baremetal-operator-system --nameprefix=baremetal-operator-
 
     if [ "${DEPLOY_BASIC_AUTH}" == "true" ]; then
-        ${KUSTOMIZE} edit add secret ironic-htpasswd --from-env-file=ironic-htpasswd
+        ${KUSTOMIZE} edit add secret ironic-htpasswd --from-file=htpasswd=ironic-htpasswd
 
         if [[ "${DEPLOY_TLS}" == "true" ]]; then
             # Basic-auth + TLS is special since TLS also means reverse proxy, which affects basic-auth.


### PR DESCRIPTION
This is a backport of upstream PR 1685 (https://github.com/metal3-io/baremetal-operator/pull/1685/).

Mount the ironic and inspector htpasswds as volumes into the ironic-image pod, instead of the IRONIC_HTPASSWD and INSPECTOR_HTPASSWD environment variables.