### PR TITLE
OCPBUGS-37262: fix(redfish): set correct idrac-redfish management interface

### DIFF
--- a/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/redfish.go
+++ b/apis/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/redfish.go
@@ -164,7 +164,7 @@ func (a *redfishiDracAccessDetails) FirmwareInterface() string {
 }
 
 func (a *redfishiDracAccessDetails) ManagementInterface() string {
-	return ipxe
+	return idracRedfish
 }
 
 func (a *redfishiDracAccessDetails) PowerInterface() string {

--- a/pkg/hardwareutils/bmc/redfish.go
+++ b/pkg/hardwareutils/bmc/redfish.go
@@ -164,7 +164,7 @@ func (a *redfishiDracAccessDetails) FirmwareInterface() string {
 }
 
 func (a *redfishiDracAccessDetails) ManagementInterface() string {
-	return ipxe
+	return idracRedfish
 }
 
 func (a *redfishiDracAccessDetails) PowerInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/redfish.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc/redfish.go
@@ -164,7 +164,7 @@ func (a *redfishiDracAccessDetails) FirmwareInterface() string {
 }
 
 func (a *redfishiDracAccessDetails) ManagementInterface() string {
-	return ipxe
+	return idracRedfish
 }
 
 func (a *redfishiDracAccessDetails) PowerInterface() string {


### PR DESCRIPTION
* to fix adding node to ironic error: "Could not find the following interface in the 'ironic.hardware.interfaces.management' entrypoint: ipxe."

Signed-off-by: Dmitri Fedotov <dmitri.fedotov@sap.com>
(cherry picked from commit c73a43ac446bd3f3d0c03a86fe153b325f18fd71)