### PR TITLE
Update go.mod directive to 1.22.0 for cachito

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/baremetal-operator
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
For cachito to work for downstream builds, we need to adjust the go.mod directive

Test downstream build: [ose-baremetal-operator-container-v4.17.0-202408202005.p0.ge257b27.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3237455)