### PR TITLE
[release-4.14] OCPBUGS-38940: [OCP] Ability to disable agent power off after deployment

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -807,14 +807,17 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 		return actionError{err}
 	}
 
+	openShiftNoAgentPowerOff := info.host.Annotations["baremetal.openshift.io/disable-agent-power-off"] == "true"
+
 	provResult, provID, err := prov.ValidateManagementAccess(
 		provisioner.ManagementAccessData{
-			BootMode:              info.host.Status.Provisioning.BootMode,
-			AutomatedCleaningMode: info.host.Spec.AutomatedCleaningMode,
-			State:                 info.host.Status.Provisioning.State,
-			CurrentImage:          getCurrentImage(info.host),
-			PreprovisioningImage:  preprovImg,
-			HasCustomDeploy:       hasCustomDeploy(info.host),
+			BootMode:                 info.host.Status.Provisioning.BootMode,
+			AutomatedCleaningMode:    info.host.Spec.AutomatedCleaningMode,
+			State:                    info.host.Status.Provisioning.State,
+			CurrentImage:             getCurrentImage(info.host),
+			PreprovisioningImage:     preprovImg,
+			HasCustomDeploy:          hasCustomDeploy(info.host),
+			OpenShiftNoAgentPowerOff: openShiftNoAgentPowerOff,
 		},
 		credsChanged,
 		info.host.Status.ErrorType == metal3api.RegistrationError)

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -528,6 +528,13 @@ func (p *ironicProvisioner) configureImages(data provisioner.ManagementAccessDat
 	updater := updateOptsBuilder(p.debugLog)
 
 	deployImageInfo := setDeployImage(p.config, bmcAccess, data.PreprovisioningImage)
+	// NOTE(dtantsur): this is an OpenShift-only extension. Remove it with
+	// a graceful period once we have real NC-SI support and don't need to
+	// work around it with fakefish.
+	if data.OpenShiftNoAgentPowerOff && deployImageInfo != nil {
+		deployImageInfo["deploy_forces_oob_reboot"] = true
+	}
+	// End of OpenShift-only extensions.
 	updater.SetDriverInfoOpts(deployImageInfo, ironicNode)
 
 	// NOTE(dtantsur): It is risky to update image information for active nodes since it may affect the ability to clean up.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -74,6 +74,11 @@ type PreprovisioningImage struct {
 }
 
 type ManagementAccessData struct {
+	// NOTE(dtantsur): this is an OpenShift-only extension. Remove it with
+	// a graceful period once we have real NC-SI support and don't need to
+	// work around it with fakefish.
+	OpenShiftNoAgentPowerOff bool
+	// End of OpenShift-only extensions.
 	BootMode              metal3api.BootMode
 	AutomatedCleaningMode metal3api.AutomatedCleaningMode
 	State                 metal3api.ProvisioningState


### PR DESCRIPTION
At the end of a normal (not live ISO) deployment, Ironic issues
a command to the agent to power off the machine from inside. This
feature avoids relying on often buggy soft power off features of BMCs
(especially IPMI-based), but is not compatible with the way FakeFish [1]
works in case of NC-SI hardware. Such hardware cannot be powered off
because doing so also removes network access to the BMC. FakeFish can
intercept any power calls but cannot intercept the agent API.

This OpenShift-only change adds a new annotation
baremetal.openshift.io/disable-agent-power-off which, if set to "true",
makes BMO configure the Ironic node with the "deploy_forces_oob_reboot"
DriverInfo flag. This flag prevents Ironic from issuing the in-band
power off request.

[1] https://github.com/openshift-metal3/fakefish

Conflicts:
	controllers/metal3.io/baremetalhost_controller.go
	pkg/provisioner/provisioner.go

(cherry picked from commit 5fc120726359bf24fb1e839cb4aa98229fd7a127)
