### PR TITLE
[4.16] OCPBUGS-49703: Handle HFC for non-redfish HW

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -880,6 +880,13 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 		return actionUpdate{}
 	}
 
+	// Check if the host can support firmware components before creating the resrouce
+	_, errGetFirmwareComponents := prov.GetFirmwareComponents()
+	supportsFirmwareComponents := true
+	if errGetFirmwareComponents != nil && errors.Is(errGetFirmwareComponents, provisioner.ErrFirmwareUpdateUnsupported) {
+		supportsFirmwareComponents = false
+	}
+
 	// Create the hostFirmwareSettings resource with same host name/namespace if it doesn't exist
 	// Create the hostFirmwareComponents resource with same host name/namespace if it doesn't exist
 	if info.host.Name != "" {
@@ -890,9 +897,11 @@ func (r *BareMetalHostReconciler) registerHost(prov provisioner.Provisioner, inf
 				info.log.Info("failed creating hostfirmwaresettings")
 				return actionError{errors.Wrap(err, "failed creating hostFirmwareSettings")}
 			}
-			if err = r.createHostFirmwareComponents(info); err != nil {
-				info.log.Info("failed creating hostfirmwarecomponents")
-				return actionError{errors.Wrap(err, "failed creating hostFirmwareComponents")}
+			if supportsFirmwareComponents {
+				if err = r.createHostFirmwareComponents(info); err != nil {
+					info.log.Info("failed creating hostfirmwarecomponents")
+					return actionError{errors.Wrap(err, "failed creating hostFirmwareComponents")}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently we are creating HFC for all BMH.
HFC only works for redfish based hardware, so we should only create when we detect that is redfish is in use.