### PR TITLE
[DNM] Add setting owner reference if HFS named after BMH exists but doesn't have owner

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -2020,6 +2020,18 @@ func (r *BareMetalHostReconciler) createHostFirmwareSettings(info *reconcileInfo
 			return errors.Wrap(err, "could not load hostFirmwareSettings resource")
 		}
 	}
+	// Necessary in case the CRD is created manually.
+
+	if !ownerReferenceExists(info.host, hfs) {
+		if err := controllerutil.SetOwnerReference(info.host, hfs, r.Scheme()); err != nil {
+			return errors.Wrap(err, "could not set bmh as owner for hostFirmwareSettings")
+		}
+		if err := r.Update(info.ctx, hfs); err != nil {
+			return errors.Wrap(err, "failure updating hostFirmwareSettings resource")
+		}
+
+		return nil
+	}
 
 	return nil
 }


### PR DESCRIPTION
(cherry picked from commit b53831b17db25f1a35c596e1921c3fe75149cbc6)