### PR TITLE
OCPBUGS-53335: CVE-2025-29781 ose-baremetal-operator-container: Bare Metal Operator (BMO) can expose any secret from other namespaces via BMCEventSubscription CRD [openshift-4.12.z]

### DIFF
--- a/apis/metal3.io/v1alpha1/bmceventsubscription_validation.go
+++ b/apis/metal3.io/v1alpha1/bmceventsubscription_validation.go
@@ -36,6 +36,12 @@ func (s *BMCEventSubscription) validateSubscription() []error {
 		errs = append(errs, fmt.Errorf("HostName cannot be empty"))
 	}
 
+	if s.Spec.HTTPHeadersRef != nil {
+		if s.Spec.HTTPHeadersRef.Namespace != s.Namespace {
+			errs = append(errs, errors.New("httpHeadersRef secret must be in the same namespace as the BMCEventSubscription"))
+		}
+	}
+
 	if s.Spec.Destination == "" {
 		errs = append(errs, fmt.Errorf("Destination cannot be empty"))
 	} else {

--- a/apis/metal3.io/v1alpha1/bmceventsubscription_validation_test.go
+++ b/apis/metal3.io/v1alpha1/bmceventsubscription_validation_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -68,6 +69,28 @@ func TestBMCEventSubscriptionValidateCreate(t *testing.T) {
 			},
 			oldS:      nil,
 			wantedErr: "Hostname-only destination must have a trailing slash",
+		},
+		{
+			name: "httpHeadersRef valid",
+			newS: &BMCEventSubscription{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BMCEventSubscriptionSpec{HostName: "worker-01", Destination: "http://localhost/abc/abc.php",
+					HTTPHeadersRef: &corev1.SecretReference{Namespace: om.Namespace, Name: "headers"}},
+			},
+			oldS:      nil,
+			wantedErr: "",
+		},
+		{
+			name: "httpHeadersRef in different namespace",
+			newS: &BMCEventSubscription{
+				TypeMeta:   tm,
+				ObjectMeta: om,
+				Spec: BMCEventSubscriptionSpec{HostName: "worker-01", Destination: "http://localhost/abc/abc.php",
+					HTTPHeadersRef: &corev1.SecretReference{Namespace: "different", Name: "headers"}},
+			},
+			oldS:      nil,
+			wantedErr: "httpHeadersRef secret must be in the same namespace as the BMCEventSubscription",
 		},
 	}
 

--- a/controllers/metal3.io/bmceventsubscription_controller.go
+++ b/controllers/metal3.io/bmceventsubscription_controller.go
@@ -248,6 +248,10 @@ func (r *BMCEventSubscriptionReconciler) getHTTPHeaders(subscription metal3v1alp
 		return headers, nil
 	}
 
+	if subscription.Spec.HTTPHeadersRef.Namespace != subscription.Namespace {
+		return headers, errors.New("httpHeadersRef secret must be in the same namespace as the BMCEventSubscription")
+	}
+
 	secret := &corev1.Secret{}
 	secretKey := types.NamespacedName{
 		Name:      subscription.Spec.HTTPHeadersRef.Name,

--- a/controllers/metal3.io/bmceventsubscription_controller_test.go
+++ b/controllers/metal3.io/bmceventsubscription_controller_test.go
@@ -1,0 +1,217 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
+	"github.com/metal3-io/baremetal-operator/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func newBMCTestReconcilerWithFixture(fix *fixture.Fixture, initObjs ...runtime.Object) *BMCEventSubscriptionReconciler {
+	c := fakeclient.NewFakeClient(initObjs...)
+	// Add a default secret that can be used by most subscriptions.
+	bmcSecret := newBMCCredsSecret(defaultSecretName, "User", "Pass")
+	err := c.Create(context.TODO(), bmcSecret)
+	if err != nil {
+		return nil
+	}
+	return &BMCEventSubscriptionReconciler{
+		Client:             c,
+		ProvisionerFactory: fix,
+		Log:                ctrl.Log.WithName("controllers").WithName("BMCEventSubscription"),
+		APIReader:          c,
+	}
+}
+
+type BMCDoneFunc func(subscription *metal3api.BMCEventSubscription, result reconcile.Result) bool
+
+func newBMCTestReconciler(initObjs ...runtime.Object) *BMCEventSubscriptionReconciler {
+	fix := fixture.Fixture{}
+	return newBMCTestReconcilerWithFixture(&fix, initObjs...)
+}
+
+func newBMCRequest(subscription *metal3api.BMCEventSubscription) ctrl.Request {
+	namespacedName := types.NamespacedName{
+		Namespace: subscription.ObjectMeta.Namespace,
+		Name:      subscription.ObjectMeta.Name,
+	}
+	return ctrl.Request{NamespacedName: namespacedName}
+}
+
+func newSubscription(name string, spec *metal3api.BMCEventSubscriptionSpec) *metal3api.BMCEventSubscription {
+	return &metal3api.BMCEventSubscription{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "BareMetalHost",
+			APIVersion: "metal3.io/v1alpha1",
+		}, ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: *spec,
+	}
+}
+
+func newDefaultNamedSubscription(t *testing.T, name string) *metal3api.BMCEventSubscription {
+	t.Helper()
+	spec := &metal3api.BMCEventSubscriptionSpec{
+		HostName:    t.Name(),
+		Destination: "user destination",
+		Context:     "user context",
+		HTTPHeadersRef: &corev1.SecretReference{
+			Name:      defaultSecretName,
+			Namespace: namespace,
+		},
+	}
+	t.Logf("newNamedSubscription(%s)", name)
+	subscription := newSubscription(name, spec)
+	return subscription
+}
+
+func newDefaultSubscription(t *testing.T) *metal3api.BMCEventSubscription {
+	t.Helper()
+	return newDefaultNamedSubscription(t, t.Name())
+}
+
+func HostWithProvisioningID(t *testing.T, host *metal3api.BareMetalHost) *metal3api.BareMetalHost {
+	t.Helper()
+	host.Status.Provisioning.ID = "made-up-id"
+	return host
+}
+
+func TestBMCAddFinalizers(t *testing.T) {
+	host := newDefaultHost(t)
+	subscription := newDefaultSubscription(t)
+	r := newBMCTestReconciler(subscription, host)
+	err := r.addFinalizer(context.Background(), subscription)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("subscription finalizers: %v", subscription.Finalizers)
+	if !utils.StringInList(subscription.Finalizers, metal3api.BMCEventSubscriptionFinalizer) {
+		t.Error("Expected finalizers to be added")
+	}
+}
+
+func TestBMCGetProvisioner(t *testing.T) {
+	host := newDefaultHost(t)
+	subscription := newDefaultSubscription(t)
+	request := newBMCRequest(subscription)
+	r := newBMCTestReconciler(subscription, host)
+	for _, tc := range []struct {
+		Scenario string
+		Host     *metal3api.BareMetalHost
+		Expected bool
+	}{
+		{
+			Scenario: "No provisioning id is provided",
+			Host:     host,
+			Expected: true,
+		},
+		{
+			Scenario: "Provisioning id is provided",
+			Host:     HostWithProvisioningID(t, host),
+			Expected: true,
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			prov, actual, err := r.getProvisioner(request, tc.Host)
+			if err != nil {
+				t.Error(err)
+			}
+			t.Log("Provisioner Details:", prov)
+			if tc.Expected && !actual {
+				t.Error("Expected a ready provisioner")
+			}
+		})
+	}
+}
+
+func TestGetHTTPHeaders(t *testing.T) {
+	// NOTE: This subscription references the defaultSecretName for http headers.
+	// The secret is automatically created by newBMCTestReconciler.
+	host := newDefaultHost(t)
+	subscription := newDefaultSubscription(t)
+	r := newBMCTestReconciler(subscription, host)
+
+	for _, tc := range []struct {
+		Scenario      string
+		Subscription  *metal3api.BMCEventSubscription
+		Secret        *corev1.Secret
+		ExpectedError bool
+	}{
+		{
+			Scenario:     "Secret exists and has some content",
+			Subscription: subscription,
+			// Already created by newBMCTestReconciler.
+			Secret:        nil,
+			ExpectedError: false,
+		},
+		{
+			Scenario: "Secret does not exist",
+			Subscription: &metal3api.BMCEventSubscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-subscription",
+					Namespace: namespace,
+				},
+				Spec: metal3api.BMCEventSubscriptionSpec{
+					HostName: host.Name,
+					HTTPHeadersRef: &corev1.SecretReference{
+						Name:      "non-existent-secret",
+						Namespace: namespace,
+					},
+				},
+			},
+			Secret:        nil,
+			ExpectedError: true,
+		},
+		{
+			Scenario: "Secret in wrong namespace",
+			Subscription: &metal3api.BMCEventSubscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-subscription",
+					Namespace: namespace,
+				},
+				Spec: metal3api.BMCEventSubscriptionSpec{
+					HostName: host.Name,
+					HTTPHeadersRef: &corev1.SecretReference{
+						Name:      "test",
+						Namespace: "separate-namespace",
+					},
+				},
+			},
+			Secret:        nil,
+			ExpectedError: true,
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			if tc.Secret != nil {
+				err := r.Create(context.Background(), tc.Secret)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			headers, err := r.getHTTPHeaders(*tc.Subscription)
+			if tc.ExpectedError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tc.ExpectedError {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if len(headers) == 0 {
+					t.Error("Expected headers but got none")
+				}
+			}
+		})
+	}
+}

--- a/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/bmceventsubscription_validation.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/bmceventsubscription_validation.go
@@ -36,6 +36,12 @@ func (s *BMCEventSubscription) validateSubscription() []error {
 		errs = append(errs, fmt.Errorf("HostName cannot be empty"))
 	}
 
+	if s.Spec.HTTPHeadersRef != nil {
+		if s.Spec.HTTPHeadersRef.Namespace != s.Namespace {
+			errs = append(errs, errors.New("httpHeadersRef secret must be in the same namespace as the BMCEventSubscription"))
+		}
+	}
+
 	if s.Spec.Destination == "" {
 		errs = append(errs, fmt.Errorf("Destination cannot be empty"))
 	} else {


### PR DESCRIPTION
The BMCEventSubscription spec uses a Secret reference for the HTTPHeadersRef field. This allows the user to specify any namespace. To prevent leaking Secrets, this commit restricts the namespace to the same namespace that the BMCEventSubscription is in.

Signed-off-by: Lennart Jern <lennart.jern@est.tech>

OCPBUGS-53335: CVE-2025-29781 ose-baremetal-operator-container: Bare Metal Operator (BMO) can expose any secret from other namespaces via BMCEventSubscription CRD [openshift-4.12.z]