### PR TITLE
[4.19] OCPBUGS-56765: Make firmware update handle only a subset of `Spec.Updates`

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1136,6 +1136,22 @@ func (r *BareMetalHostReconciler) matchProfile(info *reconcileInfo) (dirty bool,
 	return
 }
 
+func getUpdatesDifference(specUpdates []metal3api.FirmwareUpdate, statusUpdates []metal3api.FirmwareUpdate) []metal3api.FirmwareUpdate {
+	diff := []metal3api.FirmwareUpdate{}
+	// Mapping already updated components
+	updated := make(map[string]string, len(statusUpdates))
+	for _, s := range statusUpdates {
+		updated[s.Component] = s.URL
+	}
+
+	for _, firmware := range specUpdates {
+		if _, ok := updated[firmware.Component]; !ok || firmware.URL != updated[firmware.Component] {
+			diff = append(diff, firmware)
+		}
+	}
+	return diff
+}
+
 func (r *BareMetalHostReconciler) actionPreparing(prov provisioner.Provisioner, info *reconcileInfo) actionResult {
 	info.log.Info("preparing")
 
@@ -1181,7 +1197,12 @@ func (r *BareMetalHostReconciler) actionPreparing(prov provisioner.Provisioner, 
 		return actionContinue{subResourceNotReadyRetryDelay}
 	}
 	if hfcDirty {
-		prepareData.TargetFirmwareComponents = hfc.Spec.Updates
+		// Handle only Firmware Component that it is in hfc.Spec.Updates but not in hfc.Status.Updates.
+		if hfc.Status.Updates != nil {
+			prepareData.TargetFirmwareComponents = getUpdatesDifference(hfc.Spec.Updates, hfc.Status.Updates)
+		} else {
+			prepareData.TargetFirmwareComponents = hfc.Spec.Updates
+		}
 	}
 
 	provResult, started, err := prov.Prepare(prepareData, bmhDirty || hfsDirty || hfcDirty,
@@ -1429,7 +1450,12 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(prov provisioner.Provisioner
 			return actionError{fmt.Errorf("could not determine firmware components: %w", err)}
 		}
 		if hfcDirty {
-			servicingData.TargetFirmwareComponents = hfc.Spec.Updates
+			// Handle only Firmware Component that it is in hfc.Spec.Updates but not in hfc.Status.Updates.
+			if hfc.Status.Updates != nil {
+				servicingData.TargetFirmwareComponents = getUpdatesDifference(hfc.Spec.Updates, hfc.Status.Updates)
+			} else {
+				servicingData.TargetFirmwareComponents = hfc.Spec.Updates
+			}
 		}
 	}
 

--- a/controllers/metal3.io/baremetalhost_controller_test.go
+++ b/controllers/metal3.io/baremetalhost_controller_test.go
@@ -2831,6 +2831,30 @@ func TestPreprovImageAvailable(t *testing.T) {
 	}
 }
 
+func TestGetUpdatesDifference(t *testing.T) {
+	hfc := metal3api.HostFirmwareComponents{
+		Status: metal3api.HostFirmwareComponentsStatus{
+			Updates: []metal3api.FirmwareUpdate{
+				{Component: "bmc", URL: "http://example1.com/bmc.exe"},
+				{Component: "bios", URL: "http://example1.com/bios.exe"},
+			},
+		},
+		Spec: metal3api.HostFirmwareComponentsSpec{
+			Updates: []metal3api.FirmwareUpdate{
+				{Component: "bmc", URL: "http://example1.com/bmc.exe"},
+				{Component: "bios", URL: "http://example1.com/bios.exe"},
+				{Component: "bios", URL: "http://example2.com/bios.exe"}},
+		},
+	}
+
+	expected := []metal3api.FirmwareUpdate{
+		{Component: "bios", URL: "http://example2.com/bios.exe"},
+	}
+	diff := getUpdatesDifference(hfc.Spec.Updates, hfc.Status.Updates)
+
+	assert.Equal(t, expected, diff)
+}
+
 // TestHostFirwmareSettings verifies that a change to the HFS
 // can be detected as it will be used to set state to Preparing.
 func TestHostFirmwareSettings(t *testing.T) {


### PR DESCRIPTION
Cherry Pick from upstream commit metal3-io/baremetal-operator@0880ab00b9e2374528a5f4c0bc4be00de309de60