### PR TITLE
OCPBUGS-59133: Unblock BMH direct deletion when detached annotation is present

### DIFF
--- a/controllers/metal3.io/host_state_machine.go
+++ b/controllers/metal3.io/host_state_machine.go
@@ -237,6 +237,18 @@ func (hsm *hostStateMachine) checkInitiateDelete(log logr.Logger) bool {
 		} else {
 			hsm.NextState = metal3api.StateDeprovisioning
 		}
+	case metal3api.StateExternallyProvisioned:
+		if hsm.Host.OperationalStatus() == metal3api.OperationalStatusDetached {
+			if delayDeleteForDetachedHost(hsm.Host) {
+				log.Info("Delaying detached host deletion")
+				deleteDelayedForDetached.Inc()
+				return false
+			}
+			// We cannot power off a detached host.  Skip to delete.
+			hsm.NextState = metal3api.StateDeleting
+		} else {
+			hsm.NextState = metal3api.StatePoweringOffBeforeDelete
+		}
 	case metal3api.StateDeprovisioning:
 		if hsm.Host.Status.ErrorType == metal3api.RegistrationError && hsm.Host.Status.ErrorCount > 3 {
 			hsm.NextState = metal3api.StateDeleting

--- a/controllers/metal3.io/host_state_machine_test.go
+++ b/controllers/metal3.io/host_state_machine_test.go
@@ -250,6 +250,16 @@ func TestDetach(t *testing.T) {
 			ExpectedState: metal3api.StateDeleting,
 		},
 		{
+			Scenario:                  "DeleteDetachedExternallyProvisionedHost",
+			Host:                      host(metal3api.StateExternallyProvisioned).SetOperationalStatus(metal3api.OperationalStatusDetached).setDeletion().withFinalizer().build(),
+			HasDetachedAnnotation:     true,
+			ExpectedDetach:            false,
+			ExpectedDirty:             true,
+			ExpectedOperationalStatus: metal3api.OperationalStatusDetached,
+			// Should move to Deleting without any Deprovisioning
+			ExpectedState: metal3api.StateDeleting,
+		},
+		{
 			Scenario:                  "ExternallyProvisionedHost",
 			Host:                      host(metal3api.StateExternallyProvisioned).SetExternallyProvisioned().build(),
 			HasDetachedAnnotation:     false,


### PR DESCRIPTION
When a host is in provisioned or externallyProvisioned state, has detached annotation and if a delete request is raised, it should directly move to deleting state.

(cherry picked from commit f2ccfecd10482f0a545c5fd14f61bd4ae920f5cf)