### PR TITLE
OCPBUGS-57472: merge from upstream

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
@@ -464,7 +464,7 @@ func TestGetImageChecksum(t *testing.T) {
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			_, checksumType, actual := tc.Host.Spec.Image.GetChecksum()
-			assert.Equal(t, tc.Expected, actual)
+			assert.Equal(t, tc.Expected, actual == nil)
 			if tc.Expected {
 				assert.Equal(t, tc.ExpectedType, checksumType)
 			}

--- a/config/default/ironic.env
+++ b/config/default/ironic.env
@@ -1,7 +1,5 @@
 HTTP_PORT=6180
 PROVISIONING_INTERFACE=eth2
 DHCP_RANGE=172.22.0.10,172.22.0.100
-DEPLOY_KERNEL_URL=http://172.22.0.2:6180/images/ironic-python-agent.kernel
-DEPLOY_RAMDISK_URL=http://172.22.0.2:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=http://172.22.0.2:6385/v1/
 CACHEURL=http://172.22.0.1/images

--- a/config/overlays/e2e/ironic.env
+++ b/config/overlays/e2e/ironic.env
@@ -1,3 +1,1 @@
-DEPLOY_KERNEL_URL=http://192.168.222.1:6180/images/ironic-python-agent.kernel
-DEPLOY_RAMDISK_URL=http://192.168.222.1:6180/images/ironic-python-agent.initramfs
 IRONIC_ENDPOINT=https://192.168.222.1:6385/v1/

--- a/config/render/capm3.yaml
+++ b/config/render/capm3.yaml
@@ -2339,8 +2339,6 @@ spec:
 apiVersion: v1
 data:
   CACHEURL: http://172.22.0.1/images
-  DEPLOY_KERNEL_URL: http://172.22.0.2:6180/images/ironic-python-agent.kernel
-  DEPLOY_RAMDISK_URL: http://172.22.0.2:6180/images/ironic-python-agent.initramfs
   DHCP_RANGE: 172.22.0.10,172.22.0.100
   HTTP_PORT: "6180"
   IRONIC_ENDPOINT: http://172.22.0.2:6385/v1/

--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation.go
@@ -73,8 +73,8 @@ func (webhook *BareMetalHost) validateHost(host *metal3api.BareMetalHost) []erro
 	}
 
 	if host.Spec.Image != nil {
-		if err := validateImageURL(host.Spec.Image.URL); err != nil {
-			errs = append(errs, err)
+		if err := validateImage(host.Spec.Image); err != nil {
+			errs = append(errs, err...)
 		}
 	}
 
@@ -250,13 +250,19 @@ func validateStatusAnnotation(statusAnnotation string) error {
 	return nil
 }
 
-func validateImageURL(imageURL string) error {
-	_, err := url.ParseRequestURI(imageURL)
+func validateImage(image *metal3api.Image) []error {
+	var errs []error
+
+	_, err := url.ParseRequestURI(image.URL)
 	if err != nil {
-		return fmt.Errorf("image URL %s is invalid: %w", imageURL, err)
+		errs = append(errs, fmt.Errorf("image URL %s is invalid: %w", image.URL, err))
 	}
 
-	return nil
+	if _, _, err = image.GetChecksum(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errs
 }
 
 func validateRootDeviceHints(rdh *metal3api.RootDeviceHints) error {

--- a/pkg/provisioner/ironic/factory.go
+++ b/pkg/provisioner/ironic/factory.go
@@ -114,10 +114,8 @@ func loadConfigFromEnv(havePreprovImgBuilder bool) (ironicConfig, error) {
 	c.deployRamdiskURL = os.Getenv("DEPLOY_RAMDISK_URL")
 	c.deployISOURL = os.Getenv("DEPLOY_ISO_URL")
 	if !havePreprovImgBuilder {
-		if c.deployISOURL == "" &&
-			(c.deployKernelURL == "" || c.deployRamdiskURL == "") {
-			return c, errors.New("either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set")
-		}
+		// NOTE(dtantsur): with a PreprovisioningImage controller, it makes sense to set only the kernel.
+		// Without it, either both or neither must be set.
 		if (c.deployKernelURL == "" && c.deployRamdiskURL != "") ||
 			(c.deployKernelURL != "" && c.deployRamdiskURL == "") {
 			return c, errors.New("DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL can only be set together")

--- a/pkg/provisioner/ironic/factory_test.go
+++ b/pkg/provisioner/ironic/factory_test.go
@@ -99,23 +99,18 @@ func TestLoadConfigFromEnv(t *testing.T) {
 			},
 		},
 		{
-			name:          "no deploy info",
-			env:           EnvFixture{},
-			expectedError: "either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set",
-		},
-		{
 			name: "only kernel",
 			env: EnvFixture{
 				kernelURL: "http://kernel",
 			},
-			expectedError: "either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set",
+			expectedError: "DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL can only be set together",
 		},
 		{
 			name: "only ramdisk",
 			env: EnvFixture{
 				ramdiskURL: "http://ramdisk",
 			},
-			expectedError:         "either DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL or DEPLOY_ISO_URL must be set",
+			expectedError:         "DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL can only be set together",
 			expectedImgBuildError: "DEPLOY_RAMDISK_URL requires DEPLOY_KERNEL_URL to be set also",
 		},
 		{

--- a/pkg/provisioner/ironic/provision.go
+++ b/pkg/provisioner/ironic/provision.go
@@ -1,0 +1,18 @@
+package ironic
+
+import (
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
+)
+
+// validateProvisionData provides early validation for provisioning data.
+// The goal is to report errors as early as possible, before the node goes into
+// cleaning and then deployment.
+func validateProvisionData(data provisioner.ProvisionData) error {
+	if data.Image.URL != "" {
+		if _, _, err := data.Image.GetChecksum(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
- **Provide an error when required checksum is missing**
- **Validate checksums at the webhook level**
- **Leave a TODO about OCI images**
- **Stop requiring DEPLOY_KERNEL/RAMDISK**
- **Remove DEPLOY_KERNEL_URL from deployment scripts for main**
- **Vendor update**
