### PR TITLE
OCPBUGS-74365: Fix invalidDNSNameinvalidipv6 test for Go 1.24+

### DIFF
--- a/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
+++ b/internal/webhooks/metal3.io/v1alpha1/baremetalhost_validation_test.go
@@ -457,11 +457,8 @@ func TestValidateCreate(t *testing.T) {
 				Spec: metal3api.BareMetalHostSpec{
 					BMC: metal3api.BMCDetails{
 						Address: "ipmi://[fe80::fc33:62ff:fe33:8xff]:6223"}}},
-			oldBMH: nil,
-			// TODO(honza): Restore this line once we have golang 1.24.9 in CI.
-			// See ffa977e9e2f31a459857d51b4212d4a29bf933aa
-			// wantedErr: "failed to parse BMC address information: parse \"ipmi://[fe80::fc33:62ff:fe33:8xff]:6223\": invalid host: ParseAddr(\"fe80::fc33:62ff:fe33:8xff\"): unexpected character, want colon (at \"xff\")",
-			wantedErr: "failed to parse BMC address information: BMC address hostname/IP : [fe80::fc33:62ff:fe33:8xff] is invalid",
+			oldBMH:    nil,
+			wantedErr: "failed to parse BMC address information: parse \"ipmi://[fe80::fc33:62ff:fe33:8xff]:6223\": invalid host: ParseAddr(\"fe80::fc33:62ff:fe33:8xff\"): unexpected character, want colon (at \"xff\")",
 		},
 		{
 			name: "validRootDeviceHint",


### PR DESCRIPTION
Update expected error to match Go 1.24+ stricter IPv6 URL parsing.

(cherry picked from commit b3042a3674452115f221c6511ac6fdbc9c381d7f)