### PR TITLE
OCPBUGS-66071: Fix PPI for ACM

### DIFF
--- a/internal/controller/metal3.io/host_state_machine.go
+++ b/internal/controller/metal3.io/host_state_machine.go
@@ -358,19 +358,10 @@ func (hsm *hostStateMachine) ensureRegistered(info *reconcileInfo) (result actio
 		// In the deleting state the whole idea is to de-register the host
 		return result
 	case metal3api.StateRegistering:
-	case metal3api.StateInspecting, metal3api.StatePreparing:
-		// The Infrastructure operator in RHACM <=2.4 does not supply a
-		// controller for PreprovisioningImages with an InfraEnv label, (which
-		// the default controller ignores) but an image will be required
-		// if we register in the Preparing state. We know that this version
-		// never has work to do in Preparing, so it is safe to disable
-		// registration in that state. In later versions, where the controller
-		// is available and we need images, inspection will not be disabled.
-		if _, hasInfraEnv := hsm.Host.Labels["infraenvs.agent-install.openshift.io"]; hsm.NextState == metal3api.StateInspecting || hasInfraEnv {
-			if hsm.Host.InspectionDisabled() {
-				// No need to register if we are not actually going to inspect
-				return
-			}
+	case metal3api.StateInspecting:
+		if hsm.Host.InspectionDisabled() {
+			// No need to register if we are not actually going to inspect
+			return
 		}
 		fallthrough
 	default:


### PR DESCRIPTION
This reverts the changes made in a6ac8a5bfddea6eacfaaf9077599073e5e26250d because it prevents the creation of a PPI when inspection is disabled and can cause HFS to not be applied.