### PR TITLE
OCPBUGS-83866: Include image URL and checksum in provisioning error message

### DIFF
--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1275,7 +1275,8 @@ func (p *ironicProvisioner) Provision(ctx context.Context, data provisioner.Prov
 				return retryAfterDelay(0)
 			}
 			p.log.Info("found error", "msg", ironicNode.LastError)
-			return operationFailed("Image provisioning failed: " + ironicNode.LastError)
+			checksum, _, _ := data.Image.GetChecksum()
+			return operationFailed(fmt.Sprintf("Image provisioning failed (url: %s, checksum: %s): %s", data.Image.URL, checksum, ironicNode.LastError))
 		}
 		p.log.Info("recovering from previous failure")
 		if provResult, err = p.setUpForProvisioning(ctx, ironicNode, data); err != nil || provResult.Dirty || provResult.ErrorMessage != "" {

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -1276,7 +1276,11 @@ func (p *ironicProvisioner) Provision(ctx context.Context, data provisioner.Prov
 			}
 			p.log.Info("found error", "msg", ironicNode.LastError)
 			checksum, _, _ := data.Image.GetChecksum()
-			return operationFailed(fmt.Sprintf("Image provisioning failed (url: %s, checksum: %s): %s", data.Image.URL, checksum, ironicNode.LastError))
+			imageInfo := "url: " + data.Image.URL
+			if checksum != "" {
+				imageInfo += ", checksum: " + checksum
+			}
+			return operationFailed(fmt.Sprintf("Image provisioning failed (%s): %s", imageInfo, ironicNode.LastError))
 		}
 		p.log.Info("recovering from previous failure")
 		if provResult, err = p.setUpForProvisioning(ctx, ironicNode, data); err != nil || provResult.Dirty || provResult.ErrorMessage != "" {

--- a/pkg/provisioner/ironic/provision_test.go
+++ b/pkg/provisioner/ironic/provision_test.go
@@ -66,7 +66,7 @@ func TestProvision(t *testing.T) {
 			}),
 			expectedRequestAfter: 0,
 			expectedDirty:        false,
-			expectedErrorMessage: "Image provisioning failed: no work today",
+			expectedErrorMessage: "Image provisioning failed (url: http://test-image, checksum: abcd): no work today",
 		},
 		{
 			name: "cleanFail state",


### PR DESCRIPTION
Bug fix: Include image URL and checksum in provisioning error message

When image provisioning fails (`DeployFail` state), the error message now includes the image URL and checksum. Previously, the message only contained Ironic's last error, making it difficult for operators to identify which image was being deployed when the failure occurred.

**Before:**
```
Image provisioning failed: <ironic error>
```

**After:**
```
Image provisioning failed (url: http://example.com/image, checksum: abc123): <ironic error>
```

Upstream PR: https://github.com/metal3-io/baremetal-operator/pull/3298

Fixes: https://issues.redhat.com/browse/OCPBUGS-83866
