### PR TITLE
OCPBUGS-90570: Reject non-empty checksum for OCI images

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -1098,13 +1098,14 @@ func (image *Image) GetChecksum() (checksum, checksumType string, err error) {
 		return "", "", errors.New("image is not provided")
 	}
 
-	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
-		// Checksum is not required for live-iso
+	if image.IsOCI() {
+		if image.Checksum != "" {
+			return "", "", errors.New("spec.image.checksum must be empty for OCI images (oci:// images have embedded checksums)")
+		}
 		return "", "", nil
 	}
 
-	// Checksum is not required for OCI images as they have embedded checksums
-	if image.IsOCI() && image.Checksum == "" {
+	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
 		return "", "", nil
 	}
 

--- a/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types_test.go
@@ -492,7 +492,25 @@ func TestGetImageChecksum(t *testing.T) {
 					},
 				},
 			},
-			Expected:     true,
+			Expected:     false,
+			ExpectedType: "",
+		},
+		{
+			Scenario: "OCI image with live-iso format and checksum",
+			Host: BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost",
+					Namespace: "myns",
+				},
+				Spec: BareMetalHostSpec{
+					Image: &Image{
+						URL:        "oci://example.com/image:latest",
+						Checksum:   "sha256hash",
+						DiskFormat: ptr.To("live-iso"),
+					},
+				},
+			},
+			Expected:     false,
 			ExpectedType: "",
 		},
 		{

--- a/test/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/test/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -1098,13 +1098,14 @@ func (image *Image) GetChecksum() (checksum, checksumType string, err error) {
 		return "", "", errors.New("image is not provided")
 	}
 
-	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
-		// Checksum is not required for live-iso
+	if image.IsOCI() {
+		if image.Checksum != "" {
+			return "", "", errors.New("spec.image.checksum must be empty for OCI images (oci:// images have embedded checksums)")
+		}
 		return "", "", nil
 	}
 
-	// Checksum is not required for OCI images as they have embedded checksums
-	if image.IsOCI() && image.Checksum == "" {
+	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
 		return "", "", nil
 	}
 

--- a/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -1098,13 +1098,14 @@ func (image *Image) GetChecksum() (checksum, checksumType string, err error) {
 		return "", "", errors.New("image is not provided")
 	}
 
-	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
-		// Checksum is not required for live-iso
+	if image.IsOCI() {
+		if image.Checksum != "" {
+			return "", "", errors.New("spec.image.checksum must be empty for OCI images (oci:// images have embedded checksums)")
+		}
 		return "", "", nil
 	}
 
-	// Checksum is not required for OCI images as they have embedded checksums
-	if image.IsOCI() && image.Checksum == "" {
+	if image.DiskFormat != nil && *image.DiskFormat == "live-iso" {
 		return "", "", nil
 	}
 


### PR DESCRIPTION
OCPBUGS-84305: Reject non-empty checksum for OCI images

Cherry-pick of upstream metal3-io/baremetal-operator#3186 to release-4.22.

`GetChecksum()` made checksums optional for OCI images but never rejected a non-empty checksum. This causes the webhook to accept invalid configurations where both `oci://` scheme and a checksum are provided, leading to confusing provisioning failures.

This fix:
- Rejects `spec.image.checksum` when an `oci://` URL is used, returning a clear error message
- Moves the OCI check before the live-iso early return to prevent bypassing the validation with `oci://` + `live-iso` + non-empty checksum
