### PR TITLE
OCPBUGS-59259: Fix HFC error handling in actionPreparing

### DIFF
--- a/controllers/metal3.io/baremetalhost_controller.go
+++ b/controllers/metal3.io/baremetalhost_controller.go
@@ -1211,9 +1211,12 @@ func (r *BareMetalHostReconciler) actionPreparing(prov provisioner.Provisioner, 
 			info.log.Info("handling cleaning error in controller")
 			clearHostProvisioningSettings(info.host)
 		}
-		if hfcDirty {
+		if hfcDirty && hfc.Status.Updates != nil {
 			info.log.Info("handling cleaning error during firmware update")
 			hfc.Status.Updates = nil
+			if err := r.Status().Update(info.ctx, hfc); err != nil {
+				return actionError{errors.Wrap(err, "failed to update hostfirmwarecomponents status")}
+			}
 		}
 		return recordActionFailure(info, metal3api.PreparationError, provResult.ErrorMessage)
 	}


### PR DESCRIPTION
When a provisioning error happens and firmware updates are involved, we should only set the Status Updates of the HFC to nil if they are not nil.
Call Status.Update to make sure the HFC object will be updated


(cherry picked from commit a7dd63e28cf8b2fbc39eb67b775d8152cbb44c66)