### PR TITLE
[release-4.22] OCPBUGS-97940: Add BMH finalizer on PreprovisioningImage

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -58,6 +58,7 @@ const (
 	subResourceNotReadyRetryDelay = time.Second * 60
 	clarifySoftPoweroffFailure    = "Continuing with hard poweroff after soft poweroff fails. More details: "
 	hardwareDataFinalizer         = metal3api.BareMetalHostFinalizer + "/hardwareData"
+	preprovisioningImageFinalizer = metal3api.BareMetalHostFinalizer + "/preprovisioningImage"
 	NotReady                      = "Not ready"
 )
 
@@ -593,6 +594,20 @@ func (r *BareMetalHostReconciler) actionDeleting(ctx context.Context, prov provi
 		}
 	}
 
+	preprovImage := &metal3api.PreprovisioningImage{}
+	err = r.Get(ctx, client.ObjectKey{Name: info.host.Name, Namespace: info.host.Namespace}, preprovImage)
+	if err == nil {
+		if controllerutil.RemoveFinalizer(preprovImage, preprovisioningImageFinalizer) {
+			info.log.Info("removing finalizer from PreprovisioningImage")
+			err = r.Update(ctx, preprovImage)
+			if err != nil {
+				return actionError{fmt.Errorf("failed to remove PreprovisioningImage finalizer: %w", err)}
+			}
+		}
+	} else if !k8serrors.IsNotFound(err) {
+		return actionError{fmt.Errorf("failed to get PreprovisioningImage: %w", err)}
+	}
+
 	if controllerutil.RemoveFinalizer(info.host, metal3api.BareMetalHostFinalizer) {
 		info.log.Info("cleanup is complete, removed finalizer",
 			"remaining", info.host.Finalizers)
@@ -782,6 +797,9 @@ func (r *BareMetalHostReconciler) getPreprovImage(ctx context.Context, info *rec
 				Name:      key.Name,
 				Namespace: key.Namespace,
 				Labels:    info.host.Labels,
+				Finalizers: []string{
+					preprovisioningImageFinalizer,
+				},
 			},
 			Spec: expectedSpec,
 		}
@@ -797,31 +815,49 @@ func (r *BareMetalHostReconciler) getPreprovImage(ctx context.Context, info *rec
 		return nil, fmt.Errorf("failed to retrieve pre-provisioning image data: %w", err)
 	}
 
-	// If the PreprovisioningImage is being deleted, treat it as unavailable
 	if !preprovImage.DeletionTimestamp.IsZero() {
-		info.log.Info("PreprovisioningImage is being deleted, waiting for new one")
-		return nil, nil //nolint:nilnil
-	}
-
-	needsUpdate := false
-	if preprovImage.Labels == nil && len(info.host.Labels) > 0 {
-		preprovImage.Labels = make(map[string]string, len(info.host.Labels))
-	}
-	for k, v := range info.host.Labels {
-		if cur, ok := preprovImage.Labels[k]; !ok || cur != v {
-			preprovImage.Labels[k] = v
+		if !controllerutil.ContainsFinalizer(&preprovImage, preprovisioningImageFinalizer) {
+			info.log.Info("PreprovisioningImage is being deleted, waiting for new one")
+			return nil, nil //nolint:nilnil
+		}
+		info.log.Info("PreprovisioningImage is being deleted but protected by finalizer, continuing to use it")
+		if preprovImage.Status.ImageUrl != "" {
+			image := provisioner.PreprovisioningImage{
+				GeneratedImage: imageprovider.GeneratedImage{
+					ImageURL:          preprovImage.Status.ImageUrl,
+					KernelURL:         preprovImage.Status.KernelUrl,
+					ExtraKernelParams: preprovImage.Status.ExtraKernelParams,
+				},
+				Format: preprovImage.Status.Format,
+			}
+			info.log.Info("using PreprovisioningImage", "Image", image)
+			return &image, nil
+		}
+	} else {
+		needsUpdate := false
+		if !controllerutil.ContainsFinalizer(&preprovImage, preprovisioningImageFinalizer) {
+			controllerutil.AddFinalizer(&preprovImage, preprovisioningImageFinalizer)
 			needsUpdate = true
 		}
-	}
-	if !apiequality.Semantic.DeepEqual(preprovImage.Spec, expectedSpec) {
-		info.log.Info("updating PreprovisioningImage spec")
-		preprovImage.Spec = expectedSpec
-		needsUpdate = true
-	}
-	if needsUpdate {
-		info.log.Info("updating PreprovisioningImage")
-		err = r.Update(ctx, &preprovImage)
-		return nil, err
+		if preprovImage.Labels == nil && len(info.host.Labels) > 0 {
+			preprovImage.Labels = make(map[string]string, len(info.host.Labels))
+		}
+		for k, v := range info.host.Labels {
+			if cur, ok := preprovImage.Labels[k]; !ok || cur != v {
+				preprovImage.Labels[k] = v
+				needsUpdate = true
+			}
+		}
+		if !apiequality.Semantic.DeepEqual(preprovImage.Spec, expectedSpec) {
+			info.log.Info("updating PreprovisioningImage spec")
+			preprovImage.Spec = expectedSpec
+			needsUpdate = true
+		}
+		if needsUpdate {
+			info.log.Info("updating PreprovisioningImage")
+			err = r.Update(ctx, &preprovImage)
+			return nil, err
+		}
 	}
 
 	if available, err := r.preprovImageAvailable(ctx, info, &preprovImage); err != nil || !available {

--- a/internal/controller/metal3.io/baremetalhost_controller_test.go
+++ b/internal/controller/metal3.io/baremetalhost_controller_test.go
@@ -2556,6 +2556,7 @@ func TestGetPreprovImageCreateUpdate(t *testing.T) {
 	assert.Equal(t, getControllerArchitecture(), img.Spec.Architecture)
 	assert.Equal(t, secretName, img.Spec.NetworkDataName)
 	assert.Equal(t, "42", img.Labels["answer.metal3.io"])
+	assert.Contains(t, img.Finalizers, preprovisioningImageFinalizer)
 
 	newSecretName := "new_net_secret"
 	host.Spec.PreprovisioningNetworkDataName = newSecretName
@@ -2582,8 +2583,9 @@ func TestGetPreprovImage(t *testing.T) {
 	arch := getControllerArchitecture()
 	image := &metal3api.PreprovisioningImage{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      host.Name,
-			Namespace: namespace,
+			Name:       host.Name,
+			Namespace:  namespace,
+			Finalizers: []string{preprovisioningImageFinalizer},
 		},
 		Spec: metal3api.PreprovisioningImageSpec{
 			Architecture:  arch,
@@ -2692,6 +2694,80 @@ func TestGetPreprovImageBeingDeleted(t *testing.T) {
 	imgData, err := r.getPreprovImage(t.Context(), i, acceptFormats)
 	require.NoError(t, err)
 	assert.Nil(t, imgData)
+}
+
+func TestGetPreprovImageBeingDeletedWithFinalizer(t *testing.T) {
+	host := newDefaultHost(t)
+	imageURL := "http://example.test/image.iso"
+	acceptFormats := []metal3api.ImageFormat{metal3api.ImageFormatISO, metal3api.ImageFormatInitRD}
+	now := metav1.Now()
+	arch := getControllerArchitecture()
+	image := &metal3api.PreprovisioningImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              host.Name,
+			Namespace:         namespace,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{preprovisioningImageFinalizer},
+		},
+		Spec: metal3api.PreprovisioningImageSpec{
+			Architecture:  arch,
+			AcceptFormats: acceptFormats,
+		},
+		Status: metal3api.PreprovisioningImageStatus{
+			Architecture: arch,
+			Format:       metal3api.ImageFormatISO,
+			ImageUrl:     imageURL,
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(metal3api.ConditionImageReady),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(metal3api.ConditionImageError),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+	r := newTestReconciler(t, host, image)
+	i := makeReconcileInfo(host)
+
+	imgData, err := r.getPreprovImage(t.Context(), i, acceptFormats)
+	require.NoError(t, err)
+	assert.NotNil(t, imgData)
+	assert.Equal(t, imageURL, imgData.ImageURL)
+	assert.Equal(t, metal3api.ImageFormatISO, imgData.Format)
+}
+
+func TestGetPreprovImageAddsFinalizerToExisting(t *testing.T) {
+	host := newDefaultHost(t)
+	arch := getControllerArchitecture()
+	acceptFormats := []metal3api.ImageFormat{metal3api.ImageFormatISO}
+	image := &metal3api.PreprovisioningImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      host.Name,
+			Namespace: namespace,
+		},
+		Spec: metal3api.PreprovisioningImageSpec{
+			Architecture:  arch,
+			AcceptFormats: acceptFormats,
+		},
+	}
+	r := newTestReconciler(t, host, image)
+	i := makeReconcileInfo(host)
+
+	// First call adds the finalizer and returns nil (triggers requeue)
+	imgData, err := r.getPreprovImage(t.Context(), i, acceptFormats)
+	require.NoError(t, err)
+	assert.Nil(t, imgData)
+
+	// Verify finalizer was added
+	img := metal3api.PreprovisioningImage{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKey{
+		Name:      host.Name,
+		Namespace: host.Namespace,
+	}, &img))
+	assert.Contains(t, img.Finalizers, preprovisioningImageFinalizer)
 }
 
 func TestPreprovImageAvailable(t *testing.T) {

--- a/internal/controller/metal3.io/preprovisioningimage_controller.go
+++ b/internal/controller/metal3.io/preprovisioningimage_controller.go
@@ -83,6 +83,18 @@ func (r *PreprovisioningImageReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	if !img.DeletionTimestamp.IsZero() {
+		hasOtherFinalizers := false
+		for _, f := range img.Finalizers {
+			if f != metal3api.PreprovisioningImageFinalizer {
+				hasOtherFinalizers = true
+				break
+			}
+		}
+		if hasOtherFinalizers {
+			log.Info("waiting for other finalizers to be removed before cleanup",
+				"finalizers", img.Finalizers)
+			return ctrl.Result{}, nil
+		}
 		log.Info("cleaning up deleted resource")
 		if err = r.discardExistingImage(&img, log); err != nil {
 			return ctrl.Result{}, err

--- a/internal/controller/metal3.io/preprovisioningimage_controller_test.go
+++ b/internal/controller/metal3.io/preprovisioningimage_controller_test.go
@@ -7,7 +7,14 @@ import (
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/imageprovider"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type mockImageProvider struct {
@@ -201,4 +208,83 @@ func TestConfigChanged(t *testing.T) {
 			assert.Equal(t, tc.expectedHasChanged, result)
 		})
 	}
+}
+
+func newPPITestReconciler(t *testing.T, initObjs ...runtime.Object) *PreprovisioningImageReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, metal3api.AddToScheme(scheme))
+	c := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(initObjs...).
+		WithStatusSubresource(&metal3api.PreprovisioningImage{}).
+		Build()
+	return &PreprovisioningImageReconciler{
+		Client:        c,
+		Log:           ctrl.Log.WithName("test"),
+		Scheme:        scheme,
+		ImageProvider: &mockImageProvider{supportedFormats: map[metal3api.ImageFormat]bool{metal3api.ImageFormatISO: true}},
+	}
+}
+
+func TestReconcileDeleteWaitsForOtherFinalizers(t *testing.T) {
+	now := metav1.Now()
+	img := &metal3api.PreprovisioningImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-host",
+			Namespace:         "test-namespace",
+			DeletionTimestamp: &now,
+			Finalizers: []string{
+				metal3api.PreprovisioningImageFinalizer,
+				metal3api.BareMetalHostFinalizer + "/preprovisioningImage",
+			},
+		},
+		Status: metal3api.PreprovisioningImageStatus{
+			Format:   metal3api.ImageFormatISO,
+			ImageUrl: "http://example.test/image.iso",
+		},
+	}
+	r := newPPITestReconciler(t, img)
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-host", Namespace: "test-namespace"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Verify both finalizers are still present (PPI controller should wait)
+	updated := &metal3api.PreprovisioningImage{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKey{Name: "test-host", Namespace: "test-namespace"}, updated))
+	assert.Contains(t, updated.Finalizers, metal3api.PreprovisioningImageFinalizer)
+	assert.Contains(t, updated.Finalizers, metal3api.BareMetalHostFinalizer+"/preprovisioningImage")
+}
+
+func TestReconcileDeleteProceedsWithOnlyOwnFinalizer(t *testing.T) {
+	now := metav1.Now()
+	img := &metal3api.PreprovisioningImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-host",
+			Namespace:         "test-namespace",
+			DeletionTimestamp: &now,
+			Finalizers: []string{
+				metal3api.PreprovisioningImageFinalizer,
+			},
+		},
+		Status: metal3api.PreprovisioningImageStatus{
+			Format:   metal3api.ImageFormatISO,
+			ImageUrl: "http://example.test/image.iso",
+		},
+	}
+	r := newPPITestReconciler(t, img)
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-host", Namespace: "test-namespace"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// With the finalizer removed and DeletionTimestamp set, the object is deleted
+	updated := &metal3api.PreprovisioningImage{}
+	err = r.Client.Get(t.Context(), client.ObjectKey{Name: "test-host", Namespace: "test-namespace"}, updated)
+	assert.True(t, k8serrors.IsNotFound(err), "expected PPI to be deleted after finalizer removal")
 }


### PR DESCRIPTION
When a namespace with provisioned BMHs is deleted, the PPI gets deleted before the BMH can complete deprovisioning/cleaning. The BMH controller then fails to recreate the PPI because the namespace is terminating, causing a deadlock.

Fix this by having the BMH controller add its own finalizer to the PPI. The PPI controller now waits for this finalizer to be removed before discarding the image. The BMH controller removes the finalizer in actionDeleting after deprovisioning and cleaning are complete.



(cherry picked from commit c97e79d124a4825ebc7b941cb49700ff30985e80)