### PR TITLE
METAL-1918: Add servicing annotation downstream

### DIFF
--- a/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -55,6 +55,10 @@ const (
 	// when rebooting - hard/soft.
 	RebootAnnotationPrefix = "reboot.metal3.io"
 
+	// OpenShift: ServiceAnnotationPrefix is the annotation that triggers servicing
+	// (firmware updates/settings) without requiring a reboot cycle.
+	ServiceAnnotationPrefix = "service.baremetal.openshift.io"
+
 	// InspectAnnotationPrefix is used to specify if automatic introspection carried out
 	// during registration of BMH is enabled or disabled.
 	InspectAnnotationPrefix = "inspect.metal3.io"

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -1544,7 +1544,8 @@ func (r *BareMetalHostReconciler) actionDeprovisioning(ctx context.Context, prov
 	return actionComplete{}
 }
 
-func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov provisioner.Provisioner, info *reconcileInfo, hup *metal3api.HostUpdatePolicy) (result actionResult) {
+// OpenShift: serviceRequested indicates the service annotation triggered this flow
+func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov provisioner.Provisioner, info *reconcileInfo, hup *metal3api.HostUpdatePolicy, serviceRequested bool) (result actionResult) {
 	info.log.V(VerbosityLevelTrace).Info("doServiceIfNeeded started")
 	servicingData := provisioner.ServicingData{}
 
@@ -1602,6 +1603,12 @@ func (r *BareMetalHostReconciler) doServiceIfNeeded(ctx context.Context, prov pr
 
 		servicingData.HasFirmwareSpec = servicingData.HasFirmwareSpec || (hfc != nil && len(hfc.Spec.Updates) > 0)
 	}
+
+	// OpenShift: batch firmware updates when triggered via service annotation
+	if serviceRequested && len(servicingData.TargetFirmwareComponents) > 1 {
+		servicingData.AllowGroupingReboots = true
+	}
+	// End OpenShift
 
 	hasChanges := fwDirty || hfsDirty || hfcDirty
 
@@ -1740,7 +1747,7 @@ func (r *BareMetalHostReconciler) manageHostPower(ctx context.Context, prov prov
 			return actionError{fmt.Errorf("failed setting owner reference on hostUpdatePolicy: %w", err)}
 		}
 
-		result := r.doServiceIfNeeded(ctx, prov, info, hup)
+		result := r.doServiceIfNeeded(ctx, prov, info, hup, hasService)
 		if result != nil {
 			return result
 		}

--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -1727,7 +1727,10 @@ func (r *BareMetalHostReconciler) manageHostPower(ctx context.Context, prov prov
 		}
 	}
 
-	servicingAllowed := isProvisioned && !info.host.Status.PoweredOn && desiredPowerOnState
+	// OpenShift: service annotation - allow servicing while host is online
+	hasService := hasServiceAnnotation(info)
+	servicingAllowed := isProvisioned && desiredPowerOnState && (hasService || !info.host.Status.PoweredOn)
+	// End OpenShift
 	if servicingAllowed || info.host.Status.OperationalStatus == metal3api.OperationalStatusServicing || info.host.Status.ErrorType == metal3api.ServicingError {
 		var hup *metal3api.HostUpdatePolicy
 		hup, err = r.acquireHostUpdatePolicy(ctx, info)
@@ -1742,6 +1745,17 @@ func (r *BareMetalHostReconciler) manageHostPower(ctx context.Context, prov prov
 			return result
 		}
 	}
+
+	// OpenShift: service annotation - clear base annotation after servicing
+	if hasService && isProvisioned {
+		if clearServiceAnnotations(info.host) {
+			if err = r.Update(ctx, info.host); err != nil {
+				return actionError{fmt.Errorf("failed to remove service annotation from host: %w", err)}
+			}
+			return actionContinue{}
+		}
+	}
+	// End OpenShift
 
 	desiredReboot, desiredRebootMode := hasRebootAnnotation(info, !isProvisioned)
 

--- a/internal/controller/metal3.io/service_annotation_openshift.go
+++ b/internal/controller/metal3.io/service_annotation_openshift.go
@@ -1,0 +1,49 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"strings"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+)
+
+// hasServiceAnnotation returns true if the host has any service annotation
+// (base or suffixed).
+func hasServiceAnnotation(info *reconcileInfo) bool {
+	for annotation := range info.host.GetAnnotations() {
+		if isServiceAnnotation(annotation) {
+			return true
+		}
+	}
+	return false
+}
+
+// isServiceAnnotation returns true if the provided annotation is a service
+// annotation (either suffixed or not).
+func isServiceAnnotation(annotation string) bool {
+	return strings.HasPrefix(annotation, metal3api.ServiceAnnotationPrefix+"/") || annotation == metal3api.ServiceAnnotationPrefix
+}
+
+// clearServiceAnnotations deletes the base service annotation if it exists
+// on the provided host.
+func clearServiceAnnotations(host *metal3api.BareMetalHost) bool {
+	if _, exists := host.Annotations[metal3api.ServiceAnnotationPrefix]; exists {
+		delete(host.Annotations, metal3api.ServiceAnnotationPrefix)
+		return true
+	}
+	return false
+}

--- a/internal/controller/metal3.io/service_annotation_openshift_test.go
+++ b/internal/controller/metal3.io/service_annotation_openshift_test.go
@@ -1,0 +1,184 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/fixture"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// TestServiceAnnotationWithServicing tests that service annotation triggers
+// servicing without a reboot cycle.
+func TestServiceAnnotationWithServicing(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Annotations = make(map[string]string)
+	host.Annotations[metal3api.ServiceAnnotationPrefix] = ""
+	host.Status.PoweredOn = true
+	host.Status.Provisioning.State = metal3api.StateProvisioned
+	host.Spec.Online = true
+	host.Spec.Image = &metal3api.Image{URL: "foo", Checksum: "123"}
+	host.Spec.Firmware = &metal3api.FirmwareConfig{
+		VirtualizationEnabled: ptr.To(true),
+	}
+	host.Status.Provisioning.Image.URL = "foo"
+
+	hup := &metal3api.HostUpdatePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      host.Name,
+			Namespace: namespace,
+		},
+		Spec: metal3api.HostUpdatePolicySpec{
+			FirmwareSettings: metal3api.HostUpdatePolicyOnReboot,
+			FirmwareUpdates:  metal3api.HostUpdatePolicyOnReboot,
+		},
+	}
+
+	fix := fixture.Fixture{PoweredOn: true}
+	r := newTestReconcilerWithFixture(t, &fix, host, hup)
+
+	// Servicing should start without powering off
+	tryReconcile(t, r, host,
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
+			return host.Status.OperationalStatus == metal3api.OperationalStatusServicing
+		},
+	)
+
+	// Host should remain powered on during servicing
+	assert.True(t, host.Status.PoweredOn)
+
+	// Servicing completes, annotation is cleared
+	tryReconcile(t, r, host,
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
+			_, exists := host.Annotations[metal3api.ServiceAnnotationPrefix]
+			return host.Status.OperationalStatus == metal3api.OperationalStatusOK && !exists
+		},
+	)
+
+	// Host should still be powered on
+	assert.True(t, host.Status.PoweredOn)
+}
+
+// TestServiceAnnotationWithoutHUP ensures servicing is not triggered by
+// service annotation when no HostUpdatePolicy exists.
+func TestServiceAnnotationWithoutHUP(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Annotations = make(map[string]string)
+	host.Annotations[metal3api.ServiceAnnotationPrefix] = ""
+	host.Status.PoweredOn = true
+	host.Status.Provisioning.State = metal3api.StateProvisioned
+	host.Spec.Online = true
+	host.Spec.Image = &metal3api.Image{URL: "foo", Checksum: "123"}
+	host.Status.Provisioning.Image.URL = "foo"
+	host.Spec.Firmware = &metal3api.FirmwareConfig{
+		VirtualizationEnabled: ptr.To(true),
+	}
+
+	fix := fixture.Fixture{PoweredOn: true}
+	r := newTestReconcilerWithFixture(t, &fix, host)
+
+	// Without HUP, servicing should not start; annotation should be cleared
+	tryReconcile(t, r, host,
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
+			if host.Status.OperationalStatus == metal3api.OperationalStatusServicing {
+				t.Fatal("host entered servicing unexpectedly")
+			}
+			_, exists := host.Annotations[metal3api.ServiceAnnotationPrefix]
+			return host.Status.OperationalStatus == metal3api.OperationalStatusOK && !exists
+		},
+	)
+
+	assert.True(t, host.Status.PoweredOn)
+}
+
+// TestServiceAnnotationOnNonProvisionedHost ensures the service annotation
+// is preserved (not silently swallowed) on hosts that are not yet provisioned.
+func TestServiceAnnotationOnNonProvisionedHost(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Annotations = make(map[string]string)
+	host.Annotations[metal3api.ServiceAnnotationPrefix] = ""
+	host.Status.PoweredOn = true
+	host.Status.Provisioning.State = metal3api.StateAvailable
+	host.Spec.Online = true
+
+	fix := fixture.Fixture{PoweredOn: true}
+	r := newTestReconcilerWithFixture(t, &fix, host)
+
+	tryReconcile(t, r, host,
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
+			if host.Status.OperationalStatus == metal3api.OperationalStatusServicing {
+				t.Fatal("host entered servicing unexpectedly")
+			}
+			return host.Status.OperationalStatus == metal3api.OperationalStatusOK
+		},
+	)
+
+	// Annotation should survive on a non-provisioned host
+	_, exists := host.Annotations[metal3api.ServiceAnnotationPrefix]
+	assert.True(t, exists)
+}
+
+// TestServiceAnnotationSuffixed tests that suffixed service annotations
+// also trigger servicing.
+func TestServiceAnnotationSuffixed(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Annotations = make(map[string]string)
+	host.Annotations[metal3api.ServiceAnnotationPrefix+"/my-controller"] = ""
+	host.Status.PoweredOn = true
+	host.Status.Provisioning.State = metal3api.StateProvisioned
+	host.Spec.Online = true
+	host.Spec.Image = &metal3api.Image{URL: "foo", Checksum: "123"}
+	host.Spec.Firmware = &metal3api.FirmwareConfig{
+		VirtualizationEnabled: ptr.To(true),
+	}
+	host.Status.Provisioning.Image.URL = "foo"
+
+	hup := &metal3api.HostUpdatePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      host.Name,
+			Namespace: namespace,
+		},
+		Spec: metal3api.HostUpdatePolicySpec{
+			FirmwareSettings: metal3api.HostUpdatePolicyOnReboot,
+		},
+	}
+
+	fix := fixture.Fixture{PoweredOn: true}
+	r := newTestReconcilerWithFixture(t, &fix, host, hup)
+
+	tryReconcile(t, r, host,
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
+			return host.Status.OperationalStatus == metal3api.OperationalStatusServicing
+		},
+	)
+
+	assert.True(t, host.Status.PoweredOn)
+
+	tryReconcile(t, r, host,
+		func(host *metal3api.BareMetalHost, result reconcile.Result) bool {
+			return host.Status.OperationalStatus == metal3api.OperationalStatusOK
+		},
+	)
+
+	// Suffixed annotation should NOT be cleared (only base is cleared by BMO)
+	_, exists := host.Annotations[metal3api.ServiceAnnotationPrefix+"/my-controller"]
+	assert.True(t, exists)
+}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -975,13 +975,22 @@ func (p *ironicProvisioner) getNewFirmwareSettings(actualFirmwareSettings metal3
 
 // getFirmwareComponentsUpdates extract the updates in a format that ironic accepts  [{"component":"...", "url":"..."}, {"component":"...","url":".."}].
 func (p *ironicProvisioner) getFirmwareComponentsUpdates(targetFirmwareComponents []metal3api.FirmwareUpdate) (newUpdates []map[string]string) {
+	// OpenShift: send BMC updates first so Ironic processes them out-of-band
+	// before rebooting for non-BMC components
+	var nonBMC []map[string]string
 	for _, update := range targetFirmwareComponents {
-		newComponentUpdate := map[string]string{
+		entry := map[string]string{
 			"component": update.Component,
 			"url":       update.URL,
 		}
-		newUpdates = append(newUpdates, newComponentUpdate)
+		if update.Component == "bmc" {
+			newUpdates = append(newUpdates, entry)
+		} else {
+			nonBMC = append(nonBMC, entry)
+		}
 	}
+	newUpdates = append(newUpdates, nonBMC...)
+	// End OpenShift
 	return newUpdates
 }
 

--- a/pkg/provisioner/ironic/servicing.go
+++ b/pkg/provisioner/ironic/servicing.go
@@ -39,14 +39,20 @@ func (p *ironicProvisioner) buildServiceSteps(bmcAccess bmc.AccessDetails, data 
 	newUpdates := p.getFirmwareComponentsUpdates(data.TargetFirmwareComponents)
 	if len(newUpdates) != 0 {
 		p.log.Info("Applying Firmware Update clean steps", "settings", newUpdates)
+		fwArgs := map[string]any{
+			"settings": newUpdates,
+		}
+		// OpenShift: batch non-BMC updates into a single reboot
+		if data.AllowGroupingReboots {
+			fwArgs["allow_grouping_reboots"] = true
+		}
+		// End OpenShift
 		serviceSteps = append(
 			serviceSteps,
 			nodes.ServiceStep{
 				Interface: nodes.InterfaceFirmware,
 				Step:      "update",
-				Args: map[string]any{
-					"settings": newUpdates,
-				},
+				Args:      fwArgs,
 			},
 		)
 	}

--- a/pkg/provisioner/ironic/servicing.go
+++ b/pkg/provisioner/ironic/servicing.go
@@ -3,6 +3,7 @@ package ironic
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
@@ -114,6 +115,15 @@ func (p *ironicProvisioner) Service(ctx context.Context, data provisioner.Servic
 		if !data.HasFirmwareSpec {
 			return p.abortServicing(ctx, ironicNode)
 		}
+
+		// OpenShift: if Ironic rejected allow_grouping_reboots, surface a clear error
+		// and don't retry — the same request will fail the same way.
+		if strings.Contains(ironicNode.LastError, "unexpected arguments: allow_grouping_reboots") {
+			p.log.Info("Ironic does not support batched firmware updates", "lastError", ironicNode.LastError)
+			result, err = operationFailed("batched firmware update failed: Ironic does not support the allow_grouping_reboots option; upgrade Ironic or update firmware components individually using the reboot annotation")
+			return result, started, err
+		}
+		// End OpenShift
 
 		// When servicing failed and there are pending updates, we need to clean host provisioning settings
 		// If restartOnFailure is false, it means the settings aren't cleared.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -129,6 +129,9 @@ type ServicingData struct {
 	// True if any firmware spec exists (settings, components, or legacy FirmwareConfig),
 	// used to distinguish "no updates" from "user cleared spec".
 	HasFirmwareSpec bool
+	// OpenShift: when true, Ironic will batch non-BMC firmware updates
+	// into a single host reboot instead of rebooting per component.
+	AllowGroupingReboots bool
 }
 
 type ProvisionData struct {

--- a/test/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/test/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -55,6 +55,10 @@ const (
 	// when rebooting - hard/soft.
 	RebootAnnotationPrefix = "reboot.metal3.io"
 
+	// OpenShift: ServiceAnnotationPrefix is the annotation that triggers servicing
+	// (firmware updates/settings) without requiring a reboot cycle.
+	ServiceAnnotationPrefix = "service.baremetal.openshift.io"
+
 	// InspectAnnotationPrefix is used to specify if automatic introspection carried out
 	// during registration of BMH is enabled or disabled.
 	InspectAnnotationPrefix = "inspect.metal3.io"

--- a/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -55,6 +55,10 @@ const (
 	// when rebooting - hard/soft.
 	RebootAnnotationPrefix = "reboot.metal3.io"
 
+	// OpenShift: ServiceAnnotationPrefix is the annotation that triggers servicing
+	// (firmware updates/settings) without requiring a reboot cycle.
+	ServiceAnnotationPrefix = "service.baremetal.openshift.io"
+
 	// InspectAnnotationPrefix is used to specify if automatic introspection carried out
 	// during registration of BMH is enabled or disabled.
 	InspectAnnotationPrefix = "inspect.metal3.io"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for service annotations that trigger servicing on provisioned hosts without requiring them to power off first.
  * Service annotations are cleared after successful servicing while the host remains powered on.
  * Suffixed service annotations are recognized and preserved for continued processing.

* **Bug Fixes**
  * Service annotations are retained when hosts are not yet provisioned or lack a servicing policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->