### PR TITLE
OCPBUGS-99420: Create ports if they are already inspected and machine is re-registering

### DIFF
--- a/internal/controller/metal3.io/baremetalhost_controller.go
+++ b/internal/controller/metal3.io/baremetalhost_controller.go
@@ -75,6 +75,7 @@ type BareMetalHostReconciler struct {
 type reconcileInfo struct {
 	log                              logr.Logger
 	host                             *metal3api.BareMetalHost
+	hardwareData                     *metal3api.HardwareData
 	request                          ctrl.Request
 	bmcCredsSecret                   *corev1.Secret
 	preprovisioningNetworkDataSecret *corev1.Secret
@@ -148,7 +149,7 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		}
 	}
 
-	hostData, err := r.reconcileHostData(ctx, host, request)
+	hostData, hardwareData, err := r.reconcileHostData(ctx, host, request)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not reconcile host data: %w", err)
 	} else if hostData.Requeue {
@@ -228,6 +229,7 @@ func (r *BareMetalHostReconciler) Reconcile(ctx context.Context, request ctrl.Re
 	info := &reconcileInfo{
 		log:                              reqLogger.WithValues("provisioningState", initialState),
 		host:                             host,
+		hardwareData:                     hardwareData,
 		request:                          request,
 		bmcCredsSecret:                   bmcCredsSecret,
 		preprovisioningNetworkDataSecret: preprovisioningNetworkDataSecret,
@@ -938,6 +940,7 @@ func (r *BareMetalHostReconciler) registerHost(ctx context.Context, prov provisi
 			OpenShiftNoAgentPowerOff:   openShiftNoAgentPowerOff,
 			DisablePowerOff:            info.host.Spec.DisablePowerOff,
 			CPUArchitecture:            getHostArchitecture(info.host),
+			HardwareData:               info.hardwareData,
 		},
 		credsChanged,
 		info.host.Status.ErrorType == metal3api.RegistrationError)
@@ -2577,11 +2580,11 @@ func (r *BareMetalHostReconciler) SetupWithManager(mgr ctrl.Manager, preprovImgE
 	return controller.Complete(r)
 }
 
-func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *metal3api.BareMetalHost, request ctrl.Request) (result ctrl.Result, err error) {
+func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *metal3api.BareMetalHost, request ctrl.Request) (result ctrl.Result, hardwareData *metal3api.HardwareData, err error) {
 	reqLogger := r.Log.WithValues("baremetalhost", request.NamespacedName)
 
 	// Fetch the HardwareData
-	hardwareData := &metal3api.HardwareData{}
+	hardwareData = &metal3api.HardwareData{}
 	hardwareDataKey := client.ObjectKey{
 		Name:      host.Name,
 		Namespace: host.Namespace,
@@ -2597,7 +2600,7 @@ func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *m
 			controllerutil.RemoveFinalizer(hardwareData, hardwareDataFinalizer)
 			reqLogger.Info("removing finalizer from hardwareData")
 			if err := r.Update(ctx, hardwareData); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to remove hardwareData finalizer: %w", err)
+				return ctrl.Result{}, hardwareData, fmt.Errorf("failed to remove hardwareData finalizer: %w", err)
 			}
 		}
 		reqLogger.Info("hardwareData is ready to be deleted")
@@ -2625,9 +2628,9 @@ func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *m
 			}
 			errStatus := r.Status().Update(ctx, host)
 			if errStatus != nil {
-				return ctrl.Result{}, fmt.Errorf("could not restore status from annotation: %w", errStatus)
+				return ctrl.Result{}, hardwareData, fmt.Errorf("could not restore status from annotation: %w", errStatus)
 			}
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{Requeue: true}, hardwareData, nil
 		}
 		reqLogger.V(1).Info("no status cache found")
 	}
@@ -2638,10 +2641,10 @@ func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *m
 		delete(annotations, metal3api.StatusAnnotation)
 		errStatus := r.Update(ctx, host)
 		if errStatus != nil {
-			return ctrl.Result{}, fmt.Errorf("could not delete status annotation: %w", errStatus)
+			return ctrl.Result{}, hardwareData, fmt.Errorf("could not delete status annotation: %w", errStatus)
 		}
 		reqLogger.Info("deleted status annotation")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: true}, hardwareData, nil
 	}
 
 	if host.Spec.Architecture == "" && hardwareData != nil && hardwareData.Spec.HardwareDetails != nil && hardwareData.Spec.HardwareDetails.CPU.Arch != "" {
@@ -2649,9 +2652,9 @@ func (r *BareMetalHostReconciler) reconcileHostData(ctx context.Context, host *m
 		reqLogger.Info("updating architecture", "Architecture", newArch)
 		host.Spec.Architecture = newArch
 		if err := r.Client.Update(ctx, host); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update architecture: %w", err)
+			return ctrl.Result{}, hardwareData, fmt.Errorf("failed to update architecture: %w", err)
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: true}, hardwareData, nil
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, hardwareData, nil
 }

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -147,28 +147,6 @@ func (p *ironicProvisioner) validateNode(ctx context.Context, ironicNode *nodes.
 	return "", nil
 }
 
-func (p *ironicProvisioner) listAllPorts(ctx context.Context, address string) ([]ports.Port, error) {
-	var allPorts []ports.Port
-
-	opts := ports.ListOpts{
-		Fields: []string{"node_uuid"},
-	}
-
-	if address != "" {
-		opts.Address = address
-	}
-
-	pager := ports.List(p.client, opts)
-
-	allPages, err := pager.AllPages(ctx)
-
-	if err != nil {
-		return allPorts, err
-	}
-
-	return ports.ExtractPorts(allPages)
-}
-
 func (p *ironicProvisioner) getNode(ctx context.Context) (*nodes.Node, error) {
 	if p.nodeID == "" {
 		return nil, provisioner.ErrNeedsRegistration
@@ -189,48 +167,28 @@ func (p *ironicProvisioner) getNode(ctx context.Context) (*nodes.Node, error) {
 	return nil, fmt.Errorf("failed to find node by ID %s: %w", p.nodeID, err)
 }
 
-// Verifies that node has port assigned by Ironic.
-func (p *ironicProvisioner) nodeHasAssignedPort(ctx context.Context, ironicNode *nodes.Node) (bool, error) {
+// get ports in Ironic with address or node uuid filter.
+func (p *ironicProvisioner) getPorts(ctx context.Context, nodeUUID string, macAddress string) ([]ports.Port, error) {
 	opts := ports.ListOpts{
-		Fields:   []string{"node_uuid"},
-		NodeUUID: ironicNode.UUID,
+		Fields: []string{
+			"node_uuid",
+			"uuid",
+			"address",
+		},
+	}
+	if nodeUUID != "" {
+		opts.NodeUUID = nodeUUID
+	}
+	if macAddress != "" {
+		opts.Address = macAddress
 	}
 
-	pager := ports.List(p.client, opts)
-
-	allPages, err := pager.AllPages(ctx)
+	allPages, err := ports.List(p.client, opts).AllPages(ctx)
 	if err != nil {
-		return false, fmt.Errorf("failed to page over list of ports: %w", err)
+		return nil, fmt.Errorf("failed to page over list of ports: %w", err)
 	}
 
-	empty, err := allPages.IsEmpty()
-	if err != nil {
-		return false, fmt.Errorf("failed to check port list status: %w", err)
-	}
-
-	if empty {
-		p.debugLog.Info("node has no assigned port", "node", ironicNode.UUID)
-		return false, nil
-	}
-
-	p.debugLog.Info("node has assigned port", "node", ironicNode.UUID)
-	return true, nil
-}
-
-// Verify that MAC is already allocated to some node port.
-func (p *ironicProvisioner) isAddressAllocatedToPort(ctx context.Context, address string) (bool, error) {
-	allPorts, err := p.listAllPorts(ctx, address)
-	if err != nil {
-		return false, fmt.Errorf("failed to list ports for %s: %w", address, err)
-	}
-
-	if len(allPorts) == 0 {
-		p.debugLog.Info("address does not have allocated ports", "address", address)
-		return false, nil
-	}
-
-	p.debugLog.Info("address is allocated to port", "address", address, "node", allPorts[0].NodeUUID)
-	return true, nil
+	return ports.ExtractPorts(allPages)
 }
 
 // Look for an existing registration for the host in Ironic.
@@ -267,7 +225,7 @@ func (p *ironicProvisioner) findExistingHost(ctx context.Context, bootMACAddress
 	// Skip MAC-based lookup if bootMACAddress is empty to avoid false conflicts
 	if bootMACAddress != "" {
 		p.log.Info("looking for existing node by MAC", "MAC", bootMACAddress)
-		allPorts, err := p.listAllPorts(ctx, bootMACAddress)
+		allPorts, err := p.getPorts(ctx, "", bootMACAddress)
 
 		if err != nil {
 			p.log.Info("failed to find an existing port with address", "MAC", bootMACAddress)
@@ -300,10 +258,24 @@ func (p *ironicProvisioner) findExistingHost(ctx context.Context, bootMACAddress
 	return nil, nil //nolint:nilnil
 }
 
-func (p *ironicProvisioner) createPXEEnabledNodePort(ctx context.Context, uuid, macAddress string) error {
-	p.log.Info("creating PXE enabled ironic port for node", "NodeUUID", uuid, "MAC", macAddress)
+func (p *ironicProvisioner) createNodePort(ctx context.Context, uuid string, macAddress string, pxe bool) error {
+	p.log.Info("creating ironic port for node", "NodeUUID", uuid, "MAC", macAddress, "PXE status", pxe)
 
-	enable := true
+	// checking if port already exists in Ironic
+	portsList, errPortList := p.getPorts(ctx, "", macAddress)
+	if errPortList != nil {
+		p.log.Info("failed to look for existing ports in Ironic", "MAC", macAddress)
+		return errPortList
+	}
+	if portsList != nil {
+		for _, port := range portsList {
+			if port.NodeUUID != uuid {
+				return fmt.Errorf("port belongs to another node %s, MAC: %s can't register for node %s", port.NodeUUID, macAddress, uuid)
+			}
+		}
+		p.log.Info("port already exists in Ironic", "NodeUUID", uuid, "MAC", macAddress)
+		return nil
+	}
 
 	_, err := ports.Create(
 		ctx,
@@ -311,7 +283,7 @@ func (p *ironicProvisioner) createPXEEnabledNodePort(ctx context.Context, uuid, 
 		ports.CreateOpts{
 			NodeUUID:   uuid,
 			Address:    macAddress,
-			PXEEnabled: &enable,
+			PXEEnabled: &pxe,
 		}).Extract()
 	if err != nil {
 		return fmt.Errorf("failed to create ironic port for node %s, MAC: %s: %w", uuid, macAddress, err)

--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/ports"
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/baremetal-operator/pkg/hardwareutils/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/provisioner"
@@ -130,16 +131,6 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 
 		updater.SetTopLevelOpt("name", ironicNodeName(p.objectMeta), ironicNode.Name)
 
-		// When node exists but has no assigned port to it by Ironic and actuall address (MAC) is present
-		// in host config and is not allocated to different node lets try to create port for this node.
-		if p.bootMACAddress != "" {
-			err = p.ensurePort(ctx, ironicNode)
-			if err != nil {
-				result, err = transientError(err)
-				return result, provID, err
-			}
-		}
-
 		bmcAddressChanged := !bmcAddressMatches(ironicNode, driverInfo)
 
 		// The actual password is not returned from ironic, so we want to
@@ -166,6 +157,15 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 		// We don't return here because we also have to set the
 		// target provision state to manageable, which happens
 		// below.
+	}
+
+	// Try to create ports from two sources
+	// bootMACAddress if available
+	// HardwareData whenever inspection data is available.
+	err = p.createPortsForNode(ctx, ironicNode, data.HardwareData)
+	if err != nil {
+		result, err = transientError(err)
+		return result, provID, err
 	}
 
 	// If no PreprovisioningImage builder is enabled we set the Node network_data
@@ -280,35 +280,48 @@ func (p *ironicProvisioner) enrollNode(ctx context.Context, data provisioner.Man
 		return nil, true, fmt.Errorf("failed to register host in ironic: %w", err)
 	}
 
-	// If we know the MAC, create a port. Otherwise we will have
-	// to do this after we run the introspection step.
-	if p.bootMACAddress != "" {
-		err = p.createPXEEnabledNodePort(ctx, ironicNode.UUID, p.bootMACAddress)
-		if err != nil {
-			return nil, true, err
-		}
-	}
-
 	return ironicNode, false, nil
 }
 
-func (p *ironicProvisioner) ensurePort(ctx context.Context, ironicNode *nodes.Node) error {
-	nodeHasAssignedPort, err := p.nodeHasAssignedPort(ctx, ironicNode)
+func (p *ironicProvisioner) createPortsForNode(ctx context.Context, ironicNode *nodes.Node, hardwareData *metal3api.HardwareData) error {
+	if p.bootMACAddress == "" && (hardwareData == nil || hardwareData.Spec.HardwareDetails == nil) {
+		// we don't have anything to process, gracefully returning
+		return nil
+	}
+
+	// Mac/PXE status map
+	portMacsToCreate := map[string]bool{}
+	var nics []metal3api.NIC
+	if hardwareData != nil && hardwareData.Spec.HardwareDetails != nil {
+		nics = hardwareData.Spec.HardwareDetails.NIC
+	}
+
+	ironicNodePorts, err := p.getPorts(ctx, ironicNode.UUID, "")
 	if err != nil {
 		return err
 	}
 
-	if !nodeHasAssignedPort {
-		addressIsAllocatedToPort, err := p.isAddressAllocatedToPort(ctx, p.bootMACAddress)
+	ironicNodePortsList := map[string]ports.Port{}
+	for _, port := range ironicNodePorts {
+		ironicNodePortsList[port.Address] = port
+	}
+
+	for _, nic := range nics {
+		if _, ok := ironicNodePortsList[nic.MAC]; nic.MAC != "" && !ok {
+			portMacsToCreate[nic.MAC] = nic.PXE
+		}
+	}
+
+	if _, ok := ironicNodePortsList[p.bootMACAddress]; p.bootMACAddress != "" && !ok {
+		portMacsToCreate[p.bootMACAddress] = true
+	}
+
+	p.log.Info("creating ports for node", "nodeUUID", ironicNode.UUID, "MACs", portMacsToCreate)
+
+	for mac, pxe := range portMacsToCreate {
+		err := p.createNodePort(ctx, ironicNode.UUID, mac, pxe)
 		if err != nil {
 			return err
-		}
-
-		if !addressIsAllocatedToPort {
-			err = p.createPXEEnabledNodePort(ctx, ironicNode.UUID, p.bootMACAddress)
-			if err != nil {
-				return err
-			}
 		}
 	}
 

--- a/pkg/provisioner/ironic/register.go
+++ b/pkg/provisioner/ironic/register.go
@@ -159,13 +159,22 @@ func (p *ironicProvisioner) Register(ctx context.Context, data provisioner.Manag
 		// below.
 	}
 
-	// Try to create ports from two sources
-	// bootMACAddress if available
-	// HardwareData whenever inspection data is available.
-	err = p.createPortsForNode(ctx, ironicNode, data.HardwareData)
-	if err != nil {
-		result, err = transientError(err)
-		return result, provID, err
+	// NOTE(dtantsur): don't try to create ports in states where it's
+	// either impossible because of a lock or potentially disruptive.
+	switch nodes.ProvisionState(ironicNode.ProvisionState) {
+	case nodes.Enroll, nodes.Manageable, nodes.Available, nodes.Active,
+		// A failure can be caused by wrong ports, so allow creating.
+		// TODO(dtantsur): add Hold states once they're supported by Gophercloud
+		nodes.AdoptFail, nodes.InspectFail, nodes.CleanFail, nodes.DeployFail, nodes.ServiceFail, nodes.Error:
+		// Try to create ports from two sources
+		// bootMACAddress if available
+		// HardwareData whenever inspection data is available.
+		err = p.createPortsForNode(ctx, ironicNode, data.HardwareData)
+		if err != nil {
+			result, err = transientError(err)
+			return result, provID, err
+		}
+	default:
 	}
 
 	// If no PreprovisioningImage builder is enabled we set the Node network_data
@@ -284,16 +293,14 @@ func (p *ironicProvisioner) enrollNode(ctx context.Context, data provisioner.Man
 }
 
 func (p *ironicProvisioner) createPortsForNode(ctx context.Context, ironicNode *nodes.Node, hardwareData *metal3api.HardwareData) error {
-	if p.bootMACAddress == "" && (hardwareData == nil || hardwareData.Spec.HardwareDetails == nil) {
-		// we don't have anything to process, gracefully returning
-		return nil
-	}
-
-	// Mac/PXE status map
-	portMacsToCreate := map[string]bool{}
 	var nics []metal3api.NIC
 	if hardwareData != nil && hardwareData.Spec.HardwareDetails != nil {
 		nics = hardwareData.Spec.HardwareDetails.NIC
+	}
+
+	if p.bootMACAddress == "" && len(nics) == 0 {
+		// we don't have anything to process, gracefully returning
+		return nil
 	}
 
 	ironicNodePorts, err := p.getPorts(ctx, ironicNode.UUID, "")
@@ -306,6 +313,8 @@ func (p *ironicProvisioner) createPortsForNode(ctx context.Context, ironicNode *
 		ironicNodePortsList[port.Address] = port
 	}
 
+	// Mac/PXE status map
+	portMacsToCreate := map[string]bool{}
 	for _, nic := range nics {
 		if _, ok := ironicNodePortsList[nic.MAC]; nic.MAC != "" && !ok {
 			portMacsToCreate[nic.MAC] = nic.PXE

--- a/pkg/provisioner/ironic/register_test.go
+++ b/pkg/provisioner/ironic/register_test.go
@@ -1479,8 +1479,9 @@ func TestRegisterExistingNodeWithHardwareData(t *testing.T) {
 	host.Status.Provisioning.ID = "node-uuid"
 
 	existingNode := nodes.Node{
-		Name: host.Namespace + nameSeparator + host.Name,
-		UUID: "node-uuid",
+		Name:           host.Namespace + nameSeparator + host.Name,
+		UUID:           "node-uuid",
+		ProvisionState: string(nodes.Enroll),
 	}
 
 	// Create HardwareData with NIC information
@@ -1556,17 +1557,14 @@ func TestRegisterExistingNodeWithoutHardwareData(t *testing.T) {
 	host.Status.Provisioning.ID = "node-uuid"
 
 	existingNode := nodes.Node{
-		Name: host.Namespace + nameSeparator + host.Name,
-		UUID: "node-uuid",
+		Name:           host.Namespace + nameSeparator + host.Name,
+		UUID:           "node-uuid",
+		ProvisionState: string(nodes.Enroll),
 	}
 
 	ironic := testserver.NewIronic(t).Node(existingNode).NodeUpdate(nodes.Node{
 		UUID: "node-uuid",
 	})
-
-	// Set up handler to capture port creation
-	createdPorts := []ports.Port{}
-	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
 
 	ironic.Start()
 	defer ironic.Stop()
@@ -1584,6 +1582,7 @@ func TestRegisterExistingNodeWithoutHardwareData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
 	assert.Equal(t, "node-uuid", provID)
+	assert.NotContains(t, ironic.Requests, "/v1/ports")
 }
 
 // TestRegisterExistingNodeWithEmptyHardwareData ensures registration works when
@@ -1594,8 +1593,9 @@ func TestRegisterExistingNodeWithEmptyHardwareData(t *testing.T) {
 	host.Status.Provisioning.ID = "node-uuid"
 
 	existingNode := nodes.Node{
-		Name: host.Namespace + nameSeparator + host.Name,
-		UUID: "node-uuid",
+		Name:           host.Namespace + nameSeparator + host.Name,
+		UUID:           "node-uuid",
+		ProvisionState: string(nodes.Enroll),
 	}
 
 	// Create HardwareData with no NICs
@@ -1610,10 +1610,6 @@ func TestRegisterExistingNodeWithEmptyHardwareData(t *testing.T) {
 	ironic := testserver.NewIronic(t).Node(existingNode).NodeUpdate(nodes.Node{
 		UUID: "node-uuid",
 	})
-
-	// Set up handler to capture port creation
-	createdPorts := []ports.Port{}
-	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
 
 	ironic.Start()
 	defer ironic.Stop()
@@ -1631,6 +1627,65 @@ func TestRegisterExistingNodeWithEmptyHardwareData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
 	assert.Equal(t, "node-uuid", provID)
+	assert.NotContains(t, ironic.Requests, "/v1/ports")
+}
+
+// TestRegisterExistingNodeWrongStateForPortCreate ensures ports are not created
+// in transient states.
+func TestRegisterExistingNodeWrongStateForPortCreate(t *testing.T) {
+	host := makeHost()
+	host.Spec.BootMACAddress = "aa:bb:cc:dd:ee:ff"
+	host.Status.Provisioning.ID = "node-uuid"
+
+	existingNode := nodes.Node{
+		Name:           host.Namespace + nameSeparator + host.Name,
+		UUID:           "node-uuid",
+		ProvisionState: string(nodes.Inspecting),
+	}
+
+	// Create HardwareData with NIC information
+	hardwareData := &metal3api.HardwareData{
+		Spec: metal3api.HardwareDataSpec{
+			HardwareDetails: &metal3api.HardwareDetails{
+				NIC: []metal3api.NIC{
+					{
+						MAC: "aa:bb:cc:dd:ee:ff",
+						PXE: true,
+					},
+					{
+						MAC: "11:22:33:44:55:66",
+						PXE: false,
+					},
+					{
+						MAC: "77:88:99:aa:bb:cc",
+						PXE: false,
+					},
+				},
+			},
+		},
+	}
+
+	ironic := testserver.NewIronic(t).Node(existingNode).NodeUpdate(nodes.Node{
+		UUID: "node-uuid",
+	})
+
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		HardwareData: hardwareData,
+	}, false, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.ErrorMessage)
+	assert.Equal(t, "node-uuid", provID)
+	assert.NotContains(t, ironic.Requests, "/v1/ports")
 }
 
 // setupPortHandler is a helper function that creates a port handler for test servers.
@@ -1676,6 +1731,35 @@ func setupPortHandler(createdPorts *[]ports.Port) func(http.ResponseWriter, *htt
 	}
 }
 
+func setupNodeHandlerForRegister(provisionState string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var node nodes.Node
+		if err := json.Unmarshal(body, &node); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		node.UUID = "new-node-uuid"
+		node.ProvisionState = provisionState
+
+		response, _ := json.Marshal(node)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(response)
+	}
+}
+
 // TestRegisterNewNodeWithHardwareData tests the scenario where the Ironic DB is dropped
 // (node not found) and re-enrollment happens via the ironicNode == nil path.
 // This ensures ports are recreated from HardwareData even when the node doesn't exist.
@@ -1709,7 +1793,6 @@ func TestRegisterNewNodeWithHardwareData(t *testing.T) {
 
 	// Track created ports
 	createdPorts := []ports.Port{}
-	var nodeCreated *nodes.Node
 
 	ironic := testserver.NewIronic(t)
 
@@ -1717,35 +1800,12 @@ func TestRegisterNewNodeWithHardwareData(t *testing.T) {
 	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
 	// Return OK for PATCH on the new node
-	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK, "{\"uuid\": \"new-node-uuid\"}")
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK,
+		`{"uuid": "new-node-uuid", "provision_state": "enroll"}`)
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid/states/provision", "PUT", http.StatusAccepted, "{}")
 
 	// Set up handler for node creation (POST)
-	ironic.Handler("/v1/nodes", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		var node nodes.Node
-		if err := json.Unmarshal(body, &node); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		node.UUID = "new-node-uuid"
-		nodeCreated = &node
-
-		response, _ := json.Marshal(node)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		w.Write(response)
-	})
+	ironic.Handler("/v1/nodes", setupNodeHandlerForRegister(string(nodes.Enroll)))
 
 	// Set up handler to capture port creation
 	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
@@ -1766,7 +1826,6 @@ func TestRegisterNewNodeWithHardwareData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
 	assert.Equal(t, "new-node-uuid", provID)
-	assert.NotNil(t, nodeCreated, "Node should have been created")
 
 	// Verify that all three ports were created:
 	// - Boot MAC is created during enrollNode
@@ -1816,43 +1875,19 @@ func TestRegisterNewNodeWithoutBootMACButWithHardwareData(t *testing.T) {
 
 	// Track created ports
 	createdPorts := []ports.Port{}
-	var nodeCreated *nodes.Node
 
 	ironic := testserver.NewIronic(t)
 
 	// Return 404 for node lookups (simulating DB drop)
 	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
 	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
-	// Return OK for PATCH on the new node
-	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK, "{\"uuid\": \"new-node-uuid\"}")
+	// Return OK for PATCH on the new node and PUT on its state
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK,
+		`{"uuid": "new-node-uuid", "provision_state": "enroll"}`)
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid/states/provision", "PUT", http.StatusAccepted, "{}")
 
 	// Set up handler for node creation (POST)
-	ironic.Handler("/v1/nodes", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		var node nodes.Node
-		if err := json.Unmarshal(body, &node); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		node.UUID = "new-node-uuid"
-		nodeCreated = &node
-
-		response, _ := json.Marshal(node)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		w.Write(response)
-	})
+	ironic.Handler("/v1/nodes", setupNodeHandlerForRegister(string(nodes.Enroll)))
 
 	// Set up handler to capture port creation
 	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
@@ -1873,7 +1908,6 @@ func TestRegisterNewNodeWithoutBootMACButWithHardwareData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
 	assert.Equal(t, "new-node-uuid", provID)
-	assert.NotNil(t, nodeCreated, "Node should have been created")
 
 	// Verify that both ports were created from HardwareData
 	// Since no boot MAC is configured, enrollNode doesn't create any ports

--- a/pkg/provisioner/ironic/register_test.go
+++ b/pkg/provisioner/ironic/register_test.go
@@ -1,6 +1,8 @@
 package ironic
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
 
@@ -1467,4 +1469,425 @@ func TestRegisterDeprovisioningCleaningDisabledNoPreprovisioningImage(t *testing
 
 	require.NoError(t, err)
 	assert.Empty(t, result.ErrorMessage)
+}
+
+// TestRegisterExistingNodeWithHardwareData ensures ports are created from HardwareData
+// when re-registering a host that already exists in Ironic.
+func TestRegisterExistingNodeWithHardwareData(t *testing.T) {
+	host := makeHost()
+	host.Spec.BootMACAddress = "aa:bb:cc:dd:ee:ff"
+	host.Status.Provisioning.ID = "node-uuid"
+
+	existingNode := nodes.Node{
+		Name: host.Namespace + nameSeparator + host.Name,
+		UUID: "node-uuid",
+	}
+
+	// Create HardwareData with NIC information
+	hardwareData := &metal3api.HardwareData{
+		Spec: metal3api.HardwareDataSpec{
+			HardwareDetails: &metal3api.HardwareDetails{
+				NIC: []metal3api.NIC{
+					{
+						MAC: "aa:bb:cc:dd:ee:ff",
+						PXE: true,
+					},
+					{
+						MAC: "11:22:33:44:55:66",
+						PXE: false,
+					},
+					{
+						MAC: "77:88:99:aa:bb:cc",
+						PXE: false,
+					},
+				},
+			},
+		},
+	}
+
+	// Track created ports
+	createdPorts := []ports.Port{}
+
+	ironic := testserver.NewIronic(t).Node(existingNode).NodeUpdate(nodes.Node{
+		UUID: "node-uuid",
+	})
+
+	// Set up handler to capture port creation
+	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
+
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		HardwareData: hardwareData,
+	}, false, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.ErrorMessage)
+	assert.Equal(t, "node-uuid", provID)
+
+	// Verify that all three ports were created
+	assert.Len(t, createdPorts, 3, "Expected 3 ports to be created from HardwareData")
+
+	// Verify port details
+	portMACs := make(map[string]bool)
+	for _, port := range createdPorts {
+		portMACs[port.Address] = port.PXEEnabled
+		assert.Equal(t, "node-uuid", port.NodeUUID, "Port should be associated with the correct node")
+	}
+
+	// Check that all expected MACs were created with correct PXE settings
+	assert.True(t, portMACs["aa:bb:cc:dd:ee:ff"], "Boot MAC should have PXE enabled")
+	assert.False(t, portMACs["11:22:33:44:55:66"], "Second NIC should have PXE disabled")
+	assert.False(t, portMACs["77:88:99:aa:bb:cc"], "Third NIC should have PXE disabled")
+}
+
+// TestRegisterExistingNodeWithoutHardwareData ensures registration works normally
+// when HardwareData is not provided (backward compatibility).
+func TestRegisterExistingNodeWithoutHardwareData(t *testing.T) {
+	host := makeHost()
+	host.Spec.BootMACAddress = ""
+	host.Status.Provisioning.ID = "node-uuid"
+
+	existingNode := nodes.Node{
+		Name: host.Namespace + nameSeparator + host.Name,
+		UUID: "node-uuid",
+	}
+
+	ironic := testserver.NewIronic(t).Node(existingNode).NodeUpdate(nodes.Node{
+		UUID: "node-uuid",
+	})
+
+	// Set up handler to capture port creation
+	createdPorts := []ports.Port{}
+	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
+
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		HardwareData: nil, // No HardwareData provided
+	}, false, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.ErrorMessage)
+	assert.Equal(t, "node-uuid", provID)
+}
+
+// TestRegisterExistingNodeWithEmptyHardwareData ensures registration works when
+// HardwareData exists but has no NIC information.
+func TestRegisterExistingNodeWithEmptyHardwareData(t *testing.T) {
+	host := makeHost()
+	host.Spec.BootMACAddress = ""
+	host.Status.Provisioning.ID = "node-uuid"
+
+	existingNode := nodes.Node{
+		Name: host.Namespace + nameSeparator + host.Name,
+		UUID: "node-uuid",
+	}
+
+	// Create HardwareData with no NICs
+	hardwareData := &metal3api.HardwareData{
+		Spec: metal3api.HardwareDataSpec{
+			HardwareDetails: &metal3api.HardwareDetails{
+				NIC: []metal3api.NIC{},
+			},
+		},
+	}
+
+	ironic := testserver.NewIronic(t).Node(existingNode).NodeUpdate(nodes.Node{
+		UUID: "node-uuid",
+	})
+
+	// Set up handler to capture port creation
+	createdPorts := []ports.Port{}
+	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
+
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		HardwareData: hardwareData,
+	}, false, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.ErrorMessage)
+	assert.Equal(t, "node-uuid", provID)
+}
+
+// setupPortHandler is a helper function that creates a port handler for test servers.
+// It captures port creation in the provided createdPorts slice.
+func setupPortHandler(createdPorts *[]ports.Port) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			// Return empty list of ports for GET requests
+			response := map[string][]ports.Port{
+				"ports": {},
+			}
+			responseData, _ := json.Marshal(response)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(responseData)
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var port ports.Port
+		if err := json.Unmarshal(body, &port); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		port.UUID = "port-uuid-" + port.Address
+		*createdPorts = append(*createdPorts, port)
+
+		response, _ := json.Marshal(port)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(response)
+	}
+}
+
+// TestRegisterNewNodeWithHardwareData tests the scenario where the Ironic DB is dropped
+// (node not found) and re-enrollment happens via the ironicNode == nil path.
+// This ensures ports are recreated from HardwareData even when the node doesn't exist.
+func TestRegisterNewNodeWithHardwareData(t *testing.T) {
+	host := makeHost()
+	host.Spec.BootMACAddress = "aa:bb:cc:dd:ee:ff"
+	// Clear Provisioning.ID - simulating a host that was inspected but node was lost
+	host.Status.Provisioning.ID = ""
+
+	// Create HardwareData with NIC information from previous inspection
+	hardwareData := &metal3api.HardwareData{
+		Spec: metal3api.HardwareDataSpec{
+			HardwareDetails: &metal3api.HardwareDetails{
+				NIC: []metal3api.NIC{
+					{
+						MAC: "aa:bb:cc:dd:ee:ff",
+						PXE: true,
+					},
+					{
+						MAC: "11:22:33:44:55:66",
+						PXE: false,
+					},
+					{
+						MAC: "77:88:99:aa:bb:cc",
+						PXE: false,
+					},
+				},
+			},
+		},
+	}
+
+	// Track created ports
+	createdPorts := []ports.Port{}
+	var nodeCreated *nodes.Node
+
+	ironic := testserver.NewIronic(t)
+
+	// Return 404 for node lookups (simulating DB drop)
+	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
+	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
+	// Return OK for PATCH on the new node
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK, "{\"uuid\": \"new-node-uuid\"}")
+
+	// Set up handler for node creation (POST)
+	ironic.Handler("/v1/nodes", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var node nodes.Node
+		if err := json.Unmarshal(body, &node); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		node.UUID = "new-node-uuid"
+		nodeCreated = &node
+
+		response, _ := json.Marshal(node)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(response)
+	})
+
+	// Set up handler to capture port creation
+	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
+
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		HardwareData: hardwareData,
+	}, false, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.ErrorMessage)
+	assert.Equal(t, "new-node-uuid", provID)
+	assert.NotNil(t, nodeCreated, "Node should have been created")
+
+	// Verify that all three ports were created:
+	// - Boot MAC is created during enrollNode
+	// - Other two MACs are created by createPortsForNode
+	assert.Len(t, createdPorts, 3, "Expected 3 ports to be created: 1 boot MAC + 2 from HardwareData")
+
+	// Verify port details
+	portMACs := make(map[string]bool)
+	for _, port := range createdPorts {
+		portMACs[port.Address] = port.PXEEnabled
+		assert.Equal(t, "new-node-uuid", port.NodeUUID, "Port should be associated with the new node")
+	}
+
+	// Check that all expected MACs were created with correct PXE settings
+	assert.True(t, portMACs["aa:bb:cc:dd:ee:ff"], "Boot MAC should have PXE enabled")
+	assert.False(t, portMACs["11:22:33:44:55:66"], "Second NIC should have PXE disabled")
+	assert.False(t, portMACs["77:88:99:aa:bb:cc"], "Third NIC should have PXE disabled")
+}
+
+// TestRegisterNewNodeWithoutBootMACButWithHardwareData tests re-enrollment when:
+// - Ironic DB is dropped (node not found)
+// - No boot MAC is configured
+// - But HardwareData is present with inspection data
+// This ensures all ports from HardwareData are created during enrollment.
+func TestRegisterNewNodeWithoutBootMACButWithHardwareData(t *testing.T) {
+	host := makeHost()
+	host.Spec.BootMACAddress = ""    // No boot MAC configured
+	host.Status.Provisioning.ID = "" // Clear Provisioning.ID - simulating DB drop
+
+	// Create HardwareData with NIC information from previous inspection
+	hardwareData := &metal3api.HardwareData{
+		Spec: metal3api.HardwareDataSpec{
+			HardwareDetails: &metal3api.HardwareDetails{
+				NIC: []metal3api.NIC{
+					{
+						MAC: "11:22:33:44:55:66",
+						PXE: true,
+					},
+					{
+						MAC: "77:88:99:aa:bb:cc",
+						PXE: false,
+					},
+				},
+			},
+		},
+	}
+
+	// Track created ports
+	createdPorts := []ports.Port{}
+	var nodeCreated *nodes.Node
+
+	ironic := testserver.NewIronic(t)
+
+	// Return 404 for node lookups (simulating DB drop)
+	ironic.AddDefaultResponse("/v1/nodes/myns"+nameSeparator+"myhost", "GET", http.StatusNotFound, "")
+	ironic.AddDefaultResponse("/v1/nodes/myhost", "GET", http.StatusNotFound, "")
+	// Return OK for PATCH on the new node
+	ironic.AddDefaultResponse("/v1/nodes/new-node-uuid", "PATCH", http.StatusOK, "{\"uuid\": \"new-node-uuid\"}")
+
+	// Set up handler for node creation (POST)
+	ironic.Handler("/v1/nodes", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var node nodes.Node
+		if err := json.Unmarshal(body, &node); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		node.UUID = "new-node-uuid"
+		nodeCreated = &node
+
+		response, _ := json.Marshal(node)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(response)
+	})
+
+	// Set up handler to capture port creation
+	ironic.Handler("/v1/ports", setupPortHandler(&createdPorts))
+
+	ironic.Start()
+	defer ironic.Stop()
+
+	auth := clients.AuthConfig{Type: clients.NoAuth}
+	prov, err := newProvisionerWithSettings(host, bmc.Credentials{}, nullEventPublisher, ironic.Endpoint(), auth)
+	if err != nil {
+		t.Fatalf("could not create provisioner: %s", err)
+	}
+
+	result, provID, err := prov.Register(t.Context(), provisioner.ManagementAccessData{
+		HardwareData: hardwareData,
+	}, false, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.ErrorMessage)
+	assert.Equal(t, "new-node-uuid", provID)
+	assert.NotNil(t, nodeCreated, "Node should have been created")
+
+	// Verify that both ports were created from HardwareData
+	// Since no boot MAC is configured, enrollNode doesn't create any ports
+	// All ports come from createPortsForNode
+	assert.Len(t, createdPorts, 2, "Expected 2 ports to be created from HardwareData")
+
+	// Verify port details
+	portMACs := make(map[string]bool)
+	for _, port := range createdPorts {
+		portMACs[port.Address] = port.PXEEnabled
+		assert.Equal(t, "new-node-uuid", port.NodeUUID, "Port should be associated with the new node")
+	}
+
+	// Check that all expected MACs were created with correct PXE settings
+	assert.True(t, portMACs["11:22:33:44:55:66"], "First NIC should have PXE enabled")
+	assert.False(t, portMACs["77:88:99:aa:bb:cc"], "Second NIC should have PXE disabled")
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -93,6 +93,7 @@ type ManagementAccessData struct {
 	HasCustomDeploy            bool
 	DisablePowerOff            bool
 	CPUArchitecture            string
+	HardwareData               *metal3api.HardwareData
 }
 
 type AdoptData struct {


### PR DESCRIPTION
Cherry-pick of two upstream changes:

- **🐛 Create ports if they are already inspected and machine is re-registering (#3210)**
- **Only create ports in stable provision states**

Excluding `test/e2e` changes since they have a large conflict (and are not used in OCP).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ironic provisioning now uses hardware inspection data to configure network ports.
  * Ports can be created from boot MAC addresses and discovered NIC information.
  * Existing ports are preserved, assigned ports are validated, and PXE settings are retained.
  * Port setup is limited to supported provisioning states.

* **Bug Fixes**
  * Improved port handling during node registration, re-enrollment, and recovery scenarios.
  * Prevented conflicts when a port is already assigned to another node.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->